### PR TITLE
feat: tela do jogo — pergunta + 2 opções (esquerda/direita)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,9 @@
+import GameScreen from "@/components/GameScreen";
+
 export default function Home() {
   return (
-    <main className="flex h-full w-full items-center justify-center">
-      <div className="text-center px-8">
-        <h1 className="text-7xl font-bold text-white mb-6">🎯 duo-math</h1>
-        <p className="text-3xl text-gray-300">
-          Jogo de matemática acessível — em breve!
-        </p>
-      </div>
+    <main className="h-full w-full">
+      <GameScreen />
     </main>
   );
 }

--- a/src/components/AnswerOption.tsx
+++ b/src/components/AnswerOption.tsx
@@ -1,0 +1,34 @@
+interface AnswerOptionProps {
+  /** Valor da resposta exibido no botão */
+  value: number | string;
+  /** Lado da opção: esquerda ou direita */
+  side: "left" | "right";
+}
+
+/**
+ * Botão de resposta grande e acessível.
+ * Azul para esquerda, verde para direita — cores distintas
+ * que reforçam o mapeamento com os acionadores físicos.
+ */
+export default function AnswerOption({ value, side }: AnswerOptionProps) {
+  const colors =
+    side === "left"
+      ? "bg-blue-600 hover:bg-blue-500 focus-visible:bg-blue-500"
+      : "bg-green-600 hover:bg-green-500 focus-visible:bg-green-500";
+
+  const label =
+    side === "left"
+      ? `Opção esquerda: ${value}`
+      : `Opção direita: ${value}`;
+
+  return (
+    <button
+      className={`${colors} flex items-center justify-center w-full h-full rounded-3xl transition-colors select-none`}
+      aria-label={label}
+    >
+      <span className="text-7xl sm:text-8xl md:text-9xl font-bold text-white">
+        {value}
+      </span>
+    </button>
+  );
+}

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Question from "./Question";
+import AnswerOption from "./AnswerOption";
+
+/**
+ * Tela principal do jogo.
+ *
+ * Layout:
+ * ┌─────────────────────────────────┐
+ * │                                 │
+ * │         12 + 15 = ?             │  ← pergunta (topo)
+ * │                                 │
+ * │  ┌───────────┐ ┌───────────┐   │
+ * │  │    25      │ │    27     │   │  ← opções (base)
+ * │  │  (azul)    │ │  (verde)  │   │
+ * │  └───────────┘ └───────────┘   │
+ * └─────────────────────────────────┘
+ *
+ * Dados estáticos por enquanto — a lógica de geração
+ * de perguntas será implementada em issues futuras.
+ */
+export default function GameScreen() {
+  const question = "12 + 15 = ?";
+  const leftOption = 25;
+  const rightOption = 27;
+
+  return (
+    <div className="flex flex-col h-full w-full">
+      {/* ── Pergunta ── */}
+      <section
+        className="flex flex-[2] items-center justify-center px-6"
+        aria-label="Pergunta"
+      >
+        <Question text={question} />
+      </section>
+
+      {/* ── Opções de resposta ── */}
+      <section
+        className="flex flex-[3] gap-4 px-4 pb-4 sm:gap-6 sm:px-6 sm:pb-6"
+        aria-label="Opções de resposta"
+      >
+        <div className="flex-1 min-w-0">
+          <AnswerOption value={leftOption} side="left" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <AnswerOption value={rightOption} side="right" />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,0 +1,16 @@
+interface QuestionProps {
+  /** Texto da pergunta, ex: "12 + 15 = ?" */
+  text: string;
+}
+
+/**
+ * Exibe a pergunta matemática centralizada.
+ * Fonte extra-grande para acessibilidade (baixa visão).
+ */
+export default function Question({ text }: QuestionProps) {
+  return (
+    <h1 className="text-7xl sm:text-8xl md:text-9xl font-bold text-white text-center leading-tight select-none">
+      {text}
+    </h1>
+  );
+}


### PR DESCRIPTION
## Issue
Closes #22 — **Criar tela do jogo: pergunta + 2 opções (esquerda e direita)**

## O que foi feito
- **Componente `Question`**: exibe a pergunta matemática centralizada com fonte extra-grande
- **Componente `AnswerOption`**: botão de resposta com cores distintas (azul = esquerda, verde = direita)
- **Componente `GameScreen`**: layout dividido — pergunta no topo (~35%), opções na base (~65%)
- Página principal atualizada para exibir a tela do jogo

## Layout
```
┌─────────────────────────────────┐
│                                 │
│         12 + 15 = ?             │  ← pergunta (topo)
│                                 │
│  ┌───────────┐ ┌───────────┐   │
│  │    25      │ │    27     │   │  ← opções (base)
│  │  (azul)   │ │  (verde)  │   │
│  └───────────┘ └───────────┘   │
└─────────────────────────────────┘
```

## Critérios de aceite
- [x] Pergunta visível e centralizada no topo
- [x] Duas opções claramente separadas (esquerda e direita)
- [x] Fontes grandes e legíveis
- [x] Layout responsivo para tela de laptop

## Acessibilidade
- Fontes  a  (responsivas) para baixa visão
- Cores distintas (azul/verde) reforçam o mapeamento com os acionadores
-  nos botões para leitores de tela
-  para evitar seleção acidental por acionador
