### PR TITLE
feat: mapear entrada dos acionadores (teclas ← →)

### DIFF
--- a/src/components/AnswerOption.tsx
+++ b/src/components/AnswerOption.tsx
@@ -3,18 +3,34 @@ interface AnswerOptionProps {
   value: number | string;
   /** Lado da opção: esquerda ou direita */
   side: "left" | "right";
+  /** Indica se esta opção foi selecionada pelo acionador */
+  selected?: boolean;
+  /** Callback disparado ao clicar ou pressionar o acionador */
+  onSelect?: () => void;
 }
 
 /**
  * Botão de resposta grande e acessível.
  * Azul para esquerda, verde para direita — cores distintas
  * que reforçam o mapeamento com os acionadores físicos.
+ *
+ * Quando selecionado, exibe um anel branco e um leve aumento
+ * de escala para feedback visual claro (baixa visão).
  */
-export default function AnswerOption({ value, side }: AnswerOptionProps) {
+export default function AnswerOption({
+  value,
+  side,
+  selected = false,
+  onSelect,
+}: AnswerOptionProps) {
   const colors =
     side === "left"
       ? "bg-blue-600 hover:bg-blue-500 focus-visible:bg-blue-500"
       : "bg-green-600 hover:bg-green-500 focus-visible:bg-green-500";
+
+  const selectedRing = selected
+    ? "ring-4 ring-white scale-105"
+    : "";
 
   const label =
     side === "left"
@@ -23,8 +39,10 @@ export default function AnswerOption({ value, side }: AnswerOptionProps) {
 
   return (
     <button
-      className={`${colors} flex items-center justify-center w-full h-full rounded-3xl transition-colors select-none`}
+      className={`${colors} ${selectedRing} flex items-center justify-center w-full h-full rounded-3xl transition-all duration-150 select-none`}
       aria-label={label}
+      aria-pressed={selected}
+      onClick={onSelect}
     >
       <span className="text-7xl sm:text-8xl md:text-9xl font-bold text-white">
         {value}

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useCallback, useState } from "react";
 import Question from "./Question";
 import AnswerOption from "./AnswerOption";
+import { useSwitch } from "@/hooks/useSwitch";
 
 /**
  * Tela principal do jogo.
@@ -17,6 +19,7 @@ import AnswerOption from "./AnswerOption";
  * │  └───────────┘ └───────────┘   │
  * └─────────────────────────────────┘
  *
+ * Os acionadores do Gabriel (teclas ← →) selecionam as opções.
  * Dados estáticos por enquanto — a lógica de geração
  * de perguntas será implementada em issues futuras.
  */
@@ -24,6 +27,16 @@ export default function GameScreen() {
   const question = "12 + 15 = ?";
   const leftOption = 25;
   const rightOption = 27;
+
+  const [selectedSide, setSelectedSide] = useState<
+    "left" | "right" | null
+  >(null);
+
+  const handleSelect = useCallback((side: "left" | "right") => {
+    setSelectedSide(side);
+  }, []);
+
+  useSwitch({ onSelect: handleSelect });
 
   return (
     <div className="flex flex-col h-full w-full">
@@ -41,10 +54,20 @@ export default function GameScreen() {
         aria-label="Opções de resposta"
       >
         <div className="flex-1 min-w-0">
-          <AnswerOption value={leftOption} side="left" />
+          <AnswerOption
+            value={leftOption}
+            side="left"
+            selected={selectedSide === "left"}
+            onSelect={() => handleSelect("left")}
+          />
         </div>
         <div className="flex-1 min-w-0">
-          <AnswerOption value={rightOption} side="right" />
+          <AnswerOption
+            value={rightOption}
+            side="right"
+            selected={selectedSide === "right"}
+            onSelect={() => handleSelect("right")}
+          />
         </div>
       </section>
     </div>

--- a/src/hooks/useSwitch.ts
+++ b/src/hooks/useSwitch.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Side = "left" | "right";
+
+interface UseSwitchOptions {
+  /** Callback disparado quando um acionador (tecla) é pressionado. */
+  onSelect: (side: Side) => void;
+  /** Desativa a escuta de teclado quando false (ex: jogo pausado). */
+  enabled?: boolean;
+}
+
+/**
+ * Escuta as teclas de seta ← → e mapeia para os acionadores
+ * físicos do Gabriel (via Microsoft Adaptive Hub).
+ *
+ * - ArrowLeft  → opção esquerda
+ * - ArrowRight → opção direita
+ * - Todas as outras teclas são ignoradas
+ * - Previne o comportamento padrão do browser nas setas
+ * - Ignora key-repeat (segurar a tecla não dispara múltiplas vezes)
+ */
+export function useSwitch({ onSelect, enabled = true }: UseSwitchOptions) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      // Ignora key-repeat para evitar seleções múltiplas ao segurar
+      if (event.repeat) return;
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        onSelect("left");
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        onSelect("right");
+      }
+      // Demais teclas são silenciosamente ignoradas
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onSelect, enabled]);
+}


### PR DESCRIPTION
## Resumo
Implementa a issue #21 — mapeamento das teclas de seta ← → para os acionadores físicos do Gabriel.

## Alterações

### Novo: `src/hooks/useSwitch.ts`
- Hook customizado que escuta eventos `keydown` no `window`
- `ArrowLeft` → callback com `"left"`
- `ArrowRight` → callback com `"right"`
- Ignora todas as outras teclas
- Ignora `event.repeat` (segurar não dispara múltiplas vezes)
- `preventDefault()` nas setas para evitar scroll
- Prop `enabled` para desativar quando necessário (ex: jogo pausado)

### Atualizado: `AnswerOption.tsx`
- Nova prop `selected` — exibe anel branco + leve aumento de escala
- Nova prop `onSelect` — callback ao clicar (acessibilidade via mouse/touch)
- `aria-pressed` reflete o estado selecionado

### Atualizado: `GameScreen.tsx`
- Integra o hook `useSwitch` para capturar entrada dos acionadores
- Gerencia estado `selectedSide` com feedback visual
- Botões também respondem a clique para testes

## Critérios de aceite ✅
- [x] Pressionar ← seleciona a opção da esquerda
- [x] Pressionar → seleciona a opção da direita
- [x] Nenhuma outra tecla interfere no jogo
- [x] Funciona consistentemente sem delay

Closes #21