### PR TITLE
feat: validar resposta e mostrar feedback visual (certo ✅ / errado ❌)

### DIFF
--- a/src/components/AnswerOption.tsx
+++ b/src/components/AnswerOption.tsx
@@ -1,3 +1,5 @@
+export type AnswerFeedback = "correct" | "wrong" | null;
+
 interface AnswerOptionProps {
   /** Valor da resposta exibido no botão */
   value: number | string;
@@ -5,32 +7,47 @@ interface AnswerOptionProps {
   side: "left" | "right";
   /** Indica se esta opção foi selecionada pelo acionador */
   selected?: boolean;
+  /** Estado de feedback após resposta */
+  feedback?: AnswerFeedback;
   /** Callback disparado ao clicar ou pressionar o acionador */
   onSelect?: () => void;
 }
 
 /**
  * Botão de resposta grande e acessível.
- * Azul para esquerda, verde para direita — cores distintas
- * que reforçam o mapeamento com os acionadores físicos.
  *
- * Quando selecionado, exibe um anel branco e um leve aumento
- * de escala para feedback visual claro (baixa visão).
+ * Estados visuais:
+ * - Normal: azul (esquerda) / verde (direita)
+ * - Selecionado: anel branco + leve scale
+ * - Feedback correto: fundo verde brilhante + ✅
+ * - Feedback errado: fundo vermelho + ❌
  */
 export default function AnswerOption({
   value,
   side,
   selected = false,
+  feedback = null,
   onSelect,
 }: AnswerOptionProps) {
-  const colors =
-    side === "left"
-      ? "bg-blue-600 hover:bg-blue-500 focus-visible:bg-blue-500"
-      : "bg-green-600 hover:bg-green-500 focus-visible:bg-green-500";
+  /* ── Cores por estado ── */
+  let colorClass: string;
+  let indicator = "";
 
-  const selectedRing = selected
-    ? "ring-4 ring-white scale-105"
-    : "";
+  if (feedback === "correct") {
+    colorClass = "bg-green-500 ring-4 ring-white scale-105";
+    indicator = "✅";
+  } else if (feedback === "wrong") {
+    colorClass = "bg-red-500 ring-4 ring-white/50";
+    indicator = "❌";
+  } else {
+    // Estado normal — azul/verde por lado
+    const baseColor =
+      side === "left"
+        ? "bg-blue-600 hover:bg-blue-500 focus-visible:bg-blue-500"
+        : "bg-green-600 hover:bg-green-500 focus-visible:bg-green-500";
+    const selectedRing = selected ? "ring-4 ring-white scale-105" : "";
+    colorClass = `${baseColor} ${selectedRing}`;
+  }
 
   const label =
     side === "left"
@@ -39,14 +56,25 @@ export default function AnswerOption({
 
   return (
     <button
-      className={`${colors} ${selectedRing} flex items-center justify-center w-full h-full rounded-3xl transition-all duration-150 select-none`}
-      aria-label={label}
-      aria-pressed={selected}
+      className={`${colorClass} relative flex items-center justify-center w-full h-full rounded-3xl transition-all duration-200 select-none`}
+      aria-label={`${label}${feedback === "correct" ? " — correto" : ""}${feedback === "wrong" ? " — errado" : ""}`}
+      aria-pressed={selected || feedback !== null}
       onClick={onSelect}
+      disabled={feedback !== null}
     >
       <span className="text-7xl sm:text-8xl md:text-9xl font-bold text-white">
         {value}
       </span>
+
+      {/* Indicador de feedback */}
+      {indicator && (
+        <span
+          className="absolute top-2 right-3 text-4xl sm:text-5xl md:text-6xl"
+          aria-hidden="true"
+        >
+          {indicator}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -1,0 +1,35 @@
+interface FeedbackOverlayProps {
+  /** Tipo de resultado */
+  result: "correct" | "wrong";
+}
+
+/**
+ * Sobreposição semitransparente que colore toda a tela
+ * quando o jogador responde, reforçando o feedback visual.
+ *
+ * Verde para acerto, vermelho para erro.
+ * Inclui emoji grande para acessibilidade (baixa visão).
+ */
+export default function FeedbackOverlay({ result }: FeedbackOverlayProps) {
+  const isCorrect = result === "correct";
+
+  const bg = isCorrect
+    ? "bg-green-500/30"
+    : "bg-red-500/30";
+
+  const emoji = isCorrect ? "✅" : "❌";
+  const label = isCorrect ? "Resposta correta!" : "Resposta errada!";
+
+  return (
+    <div
+      className={`${bg} absolute inset-0 z-10 flex items-center justify-center pointer-events-none transition-opacity duration-200`}
+      role="status"
+      aria-live="assertive"
+      aria-label={label}
+    >
+      <span className="text-9xl sm:text-[12rem] md:text-[14rem] drop-shadow-lg animate-bounce">
+        {emoji}
+      </span>
+    </div>
+  );
+}

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -3,41 +3,69 @@
 import { useCallback, useState } from "react";
 import Question from "./Question";
 import AnswerOption from "./AnswerOption";
+import FeedbackOverlay from "./FeedbackOverlay";
 import { useSwitch } from "@/hooks/useSwitch";
 import { generateQuestion, type MathQuestion } from "@/lib/generateQuestion";
+
+import type { AnswerFeedback } from "./AnswerOption";
+
+type GamePhase = "playing" | "feedback";
 
 /**
  * Tela principal do jogo.
  *
- * Layout:
- * ┌─────────────────────────────────┐
- * │                                 │
- * │         12 + 15 = ?             │  ← pergunta (topo)
- * │                                 │
- * │  ┌───────────┐ ┌───────────┐   │
- * │  │    25      │ │    27     │   │  ← opções (base)
- * │  │  (azul)    │ │  (verde)  │   │
- * │  └───────────┘ └───────────┘   │
- * └─────────────────────────────────┘
- *
- * Os acionadores do Gabriel (teclas ← →) selecionam as opções.
- * Questões geradas aleatoriamente com as 4 operações básicas.
+ * Fluxo:
+ * 1. Exibe questão gerada aleatoriamente
+ * 2. Jogador pressiona ← ou → (acionadores)
+ * 3. Valida resposta e mostra feedback visual:
+ *    - Acerto → fundo verde + ✅
+ *    - Erro   → fundo vermelho + ❌ + destaque na resposta certa
+ * 4. Input bloqueado durante o feedback
  */
 export default function GameScreen() {
   const [question] = useState<MathQuestion>(() => generateQuestion());
+  const [phase, setPhase] = useState<GamePhase>("playing");
+  const [selectedSide, setSelectedSide] = useState<"left" | "right" | null>(null);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
-  const [selectedSide, setSelectedSide] = useState<
-    "left" | "right" | null
-  >(null);
+  const handleSelect = useCallback(
+    (side: "left" | "right") => {
+      if (phase !== "playing") return;
 
-  const handleSelect = useCallback((side: "left" | "right") => {
-    setSelectedSide(side);
-  }, []);
+      const correct = side === question.correctSide;
+      setSelectedSide(side);
+      setIsCorrect(correct);
+      setPhase("feedback");
+    },
+    [phase, question.correctSide]
+  );
 
-  useSwitch({ onSelect: handleSelect });
+  useSwitch({ onSelect: handleSelect, enabled: phase === "playing" });
+
+  /* ── Feedback por opção ── */
+  function getFeedback(side: "left" | "right"): AnswerFeedback {
+    if (phase !== "feedback" || selectedSide === null) return null;
+
+    // Opção que o jogador escolheu
+    if (side === selectedSide) {
+      return isCorrect ? "correct" : "wrong";
+    }
+
+    // Opção que o jogador NÃO escolheu — destaca se era a correta
+    if (!isCorrect && side === question.correctSide) {
+      return "correct";
+    }
+
+    return null;
+  }
 
   return (
-    <div className="flex flex-col h-full w-full">
+    <div className="relative flex flex-col h-full w-full">
+      {/* ── Overlay de feedback ── */}
+      {phase === "feedback" && isCorrect !== null && (
+        <FeedbackOverlay result={isCorrect ? "correct" : "wrong"} />
+      )}
+
       {/* ── Pergunta ── */}
       <section
         className="flex flex-[2] items-center justify-center px-6"
@@ -55,7 +83,8 @@ export default function GameScreen() {
           <AnswerOption
             value={question.leftValue}
             side="left"
-            selected={selectedSide === "left"}
+            selected={phase === "playing" && selectedSide === "left"}
+            feedback={getFeedback("left")}
             onSelect={() => handleSelect("left")}
           />
         </div>
@@ -63,7 +92,8 @@ export default function GameScreen() {
           <AnswerOption
             value={question.rightValue}
             side="right"
-            selected={selectedSide === "right"}
+            selected={phase === "playing" && selectedSide === "right"}
+            feedback={getFeedback("right")}
             onSelect={() => handleSelect("right")}
           />
         </div>


### PR DESCRIPTION
## Resumo
Implementa a issue #19 — validação de resposta com feedback visual claro para acerto e erro.

## Alterações

### Novo: `FeedbackOverlay.tsx`
- Sobreposição semitransparente em toda a tela (verde/vermelho)
- Emoji gigante (✅ ou ❌) com animação bounce — visível para baixa visão
- `aria-live="assertive"` para leitores de tela

### Atualizado: `AnswerOption.tsx`
- Nova prop `feedback: "correct" | "wrong" | null`
- Correto: fundo verde + anel branco + ✅ no canto
- Errado: fundo vermelho + ❌ no canto
- `disabled` durante feedback para bloquear cliques
- Exporta tipo `AnswerFeedback`

### Atualizado: `GameScreen.tsx`
- Máquina de estados: `playing` → `feedback`
- Verifica se lado selecionado === `correctSide`
- No erro, destaca qual era a resposta correta (verde)
- `useSwitch({ enabled: phase === "playing" })` bloqueia entrada durante feedback

## Critérios de aceite ✅
- [x] Acerto: tela fica verde com indicação clara
- [x] Erro: tela fica vermelha e mostra qual era a resposta certa
- [x] Feedback visível e com alto contraste
- [x] Não aceita nova entrada durante o feedback

Closes #19