### PR TITLE
feat: avançar automaticamente para próxima questão após resposta

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Question from "./Question";
 import AnswerOption from "./AnswerOption";
 import FeedbackOverlay from "./FeedbackOverlay";
@@ -11,23 +11,73 @@ import type { AnswerFeedback } from "./AnswerOption";
 
 type GamePhase = "playing" | "feedback";
 
+/** Tempo em ms que o feedback fica visível antes de avançar. */
+const FEEDBACK_DURATION_MS = 2500;
+
+/** Tempo em ms da transição de fade entre questões. */
+const FADE_MS = 300;
+
 /**
  * Tela principal do jogo.
  *
  * Fluxo:
  * 1. Exibe questão gerada aleatoriamente
  * 2. Jogador pressiona ← ou → (acionadores)
- * 3. Valida resposta e mostra feedback visual:
- *    - Acerto → fundo verde + ✅
- *    - Erro   → fundo vermelho + ❌ + destaque na resposta certa
- * 4. Input bloqueado durante o feedback
+ * 3. Valida resposta e mostra feedback visual (2,5 s)
+ * 4. Fade-out → nova questão → fade-in
+ * 5. Repete
  */
 export default function GameScreen() {
-  const [question] = useState<MathQuestion>(() => generateQuestion());
+  const [question, setQuestion] = useState<MathQuestion>(() =>
+    generateQuestion()
+  );
   const [phase, setPhase] = useState<GamePhase>("playing");
-  const [selectedSide, setSelectedSide] = useState<"left" | "right" | null>(null);
+  const [selectedSide, setSelectedSide] = useState<"left" | "right" | null>(
+    null
+  );
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
+  /** Controla a opacidade para transição suave entre questões. */
+  const [visible, setVisible] = useState(true);
+
+  /** Ref para limpar timers no unmount. */
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  /* ── Limpa timers ao desmontar ── */
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+    };
+  }, []);
+
+  /* ── Avanço automático após feedback ── */
+  useEffect(() => {
+    if (phase !== "feedback") return;
+
+    // Após FEEDBACK_DURATION_MS, inicia o fade-out
+    const t1 = setTimeout(() => {
+      setVisible(false);
+
+      // Após a animação de fade-out, reseta tudo com nova questão
+      const t2 = setTimeout(() => {
+        setQuestion(generateQuestion());
+        setSelectedSide(null);
+        setIsCorrect(null);
+        setPhase("playing");
+        setVisible(true);
+      }, FADE_MS);
+
+      timersRef.current.push(t2);
+    }, FEEDBACK_DURATION_MS);
+
+    timersRef.current.push(t1);
+
+    return () => {
+      clearTimeout(t1);
+    };
+  }, [phase]);
+
+  /* ── Seleção de resposta ── */
   const handleSelect = useCallback(
     (side: "left" | "right") => {
       if (phase !== "playing") return;
@@ -46,12 +96,10 @@ export default function GameScreen() {
   function getFeedback(side: "left" | "right"): AnswerFeedback {
     if (phase !== "feedback" || selectedSide === null) return null;
 
-    // Opção que o jogador escolheu
     if (side === selectedSide) {
       return isCorrect ? "correct" : "wrong";
     }
 
-    // Opção que o jogador NÃO escolheu — destaca se era a correta
     if (!isCorrect && side === question.correctSide) {
       return "correct";
     }
@@ -66,38 +114,47 @@ export default function GameScreen() {
         <FeedbackOverlay result={isCorrect ? "correct" : "wrong"} />
       )}
 
-      {/* ── Pergunta ── */}
-      <section
-        className="flex flex-[2] items-center justify-center px-6"
-        aria-label="Pergunta"
+      {/* ── Conteúdo com transição de opacidade ── */}
+      <div
+        className="flex flex-col flex-1 transition-opacity ease-in-out"
+        style={{
+          opacity: visible ? 1 : 0,
+          transitionDuration: `${FADE_MS}ms`,
+        }}
       >
-        <Question text={question.text} />
-      </section>
+        {/* ── Pergunta ── */}
+        <section
+          className="flex flex-[2] items-center justify-center px-6"
+          aria-label="Pergunta"
+        >
+          <Question text={question.text} />
+        </section>
 
-      {/* ── Opções de resposta ── */}
-      <section
-        className="flex flex-[3] gap-4 px-4 pb-4 sm:gap-6 sm:px-6 sm:pb-6"
-        aria-label="Opções de resposta"
-      >
-        <div className="flex-1 min-w-0">
-          <AnswerOption
-            value={question.leftValue}
-            side="left"
-            selected={phase === "playing" && selectedSide === "left"}
-            feedback={getFeedback("left")}
-            onSelect={() => handleSelect("left")}
-          />
-        </div>
-        <div className="flex-1 min-w-0">
-          <AnswerOption
-            value={question.rightValue}
-            side="right"
-            selected={phase === "playing" && selectedSide === "right"}
-            feedback={getFeedback("right")}
-            onSelect={() => handleSelect("right")}
-          />
-        </div>
-      </section>
+        {/* ── Opções de resposta ── */}
+        <section
+          className="flex flex-[3] gap-4 px-4 pb-4 sm:gap-6 sm:px-6 sm:pb-6"
+          aria-label="Opções de resposta"
+        >
+          <div className="flex-1 min-w-0">
+            <AnswerOption
+              value={question.leftValue}
+              side="left"
+              selected={phase === "playing" && selectedSide === "left"}
+              feedback={getFeedback("left")}
+              onSelect={() => handleSelect("left")}
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            <AnswerOption
+              value={question.rightValue}
+              side="right"
+              selected={phase === "playing" && selectedSide === "right"}
+              feedback={getFeedback("right")}
+              onSelect={() => handleSelect("right")}
+            />
+          </div>
+        </section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
Implementa a issue #18 — avanço automático para a próxima questão após o feedback visual.

## Alterações

### Atualizado: `GameScreen.tsx`
- Após feedback (2,5s), dispara fade-out suave (300ms de opacidade)
- Gera nova questão com `generateQuestion()` e reseta todo o estado
- Fade-in com a nova pergunta — sem flicker/piscada
- Timers armazenados em `useRef` e limpos no unmount (sem memory leak)
- Constantes configuráveis: `FEEDBACK_DURATION_MS` (2500) e `FADE_MS` (300)

## Fluxo completo agora
```
playing → jogador seleciona → feedback (2,5s)
       → fade-out (300ms) → nova questão → fade-in → playing
```

## Critérios de aceite ✅
- [x] Nova questão carrega automaticamente após o feedback
- [x] Intervalo suficiente para ver o feedback (2,5s)
- [x] Transição suave sem flicker

🎉 *Última issue da fase-2-mvp!* O jogo agora tem o loop completo: pergunta → resposta → feedback → próxima.

Closes #18