### PR TITLE
feat: animação de destaque ao selecionar opção (scale + glow)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,3 +46,20 @@ body {
     0 2px 8px rgba(0, 0, 0, 0.7),
     0 0 2px rgba(0, 0, 0, 0.9);
 }
+
+/* ── Animação de destaque ao selecionar opção (acionador) ── */
+@keyframes selection-glow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(253, 224, 71, 0);
+  }
+  50% {
+    box-shadow: 0 0 40px 15px rgba(253, 224, 71, 0.7);
+  }
+  100% {
+    box-shadow: 0 0 25px 10px rgba(253, 224, 71, 0.5);
+  }
+}
+
+.animate-selection-glow {
+  animation: selection-glow 400ms ease-out forwards;
+}

--- a/src/components/AnswerOption.tsx
+++ b/src/components/AnswerOption.tsx
@@ -7,6 +7,8 @@ interface AnswerOptionProps {
   side: "left" | "right";
   /** Indica se esta opção foi selecionada pelo acionador */
   selected?: boolean;
+  /** Indica que esta opção está sendo selecionada (animação de destaque) */
+  selecting?: boolean;
   /** Estado de feedback após resposta */
   feedback?: AnswerFeedback;
   /** Callback disparado ao clicar ou pressionar o acionador */
@@ -20,19 +22,29 @@ interface AnswerOptionProps {
  *   green-800 (#166534)  →  7,3 : 1  ✅
  *   green-900 (#14532d)  →  8,4 : 1  ✅  (feedback correto)
  *   red-800   (#991b1b)  →  8,4 : 1  ✅  (feedback errado)
+ *
+ * Anel de seleção amarelo (yellow-300 #fde047):
+ *   vs blue-800  →  6,7 : 1  ✅  (decorativo, claramente visível)
+ *   vs green-800 →  7,2 : 1  ✅
  */
 
 /**
  * Botão de resposta grande e acessível.
  *
+ * Estados visuais:
+ * 1. Padrão       — cor de fundo do lado, sem anel
+ * 2. Selecionando — scale-up, anel amarelo grosso, glow pulsante (~300 ms)
+ * 3. Correto      — verde escuro, anel branco, ✅
+ * 4. Errado       — vermelho escuro, anel branco, ❌
+ *
  * Alto contraste + sombra de texto para baixa visão.
  * Números mínimos de 72 px (≥ 64 px exigidos).
- * Anel de seleção grosso (6 px) para visibilidade.
  */
 export default function AnswerOption({
   value,
   side,
   selected = false,
+  selecting = false,
   feedback = null,
   onSelect,
 }: AnswerOptionProps) {
@@ -46,6 +58,10 @@ export default function AnswerOption({
   } else if (feedback === "wrong") {
     colorClass = "bg-red-800 ring-[6px] ring-white/60";
     indicator = "❌";
+  } else if (selecting) {
+    /* Destaque ao selecionar: scale-up + anel amarelo + glow animado */
+    const baseColor = side === "left" ? "bg-blue-800" : "bg-green-800";
+    colorClass = `${baseColor} ring-[8px] ring-yellow-300 scale-110 brightness-110 animate-selection-glow`;
   } else {
     const baseColor =
       side === "left"
@@ -62,11 +78,11 @@ export default function AnswerOption({
 
   return (
     <button
-      className={`${colorClass} relative flex items-center justify-center w-full h-full rounded-3xl transition-all duration-200 select-none`}
-      aria-label={`${label}${feedback === "correct" ? " — correto" : ""}${feedback === "wrong" ? " — errado" : ""}`}
-      aria-pressed={selected || feedback !== null}
+      className={`${colorClass} relative flex items-center justify-center w-full h-full rounded-3xl transition-all duration-300 select-none`}
+      aria-label={`${label}${selecting ? " — selecionando" : ""}${feedback === "correct" ? " — correto" : ""}${feedback === "wrong" ? " — errado" : ""}`}
+      aria-pressed={selected || selecting || feedback !== null}
       onClick={onSelect}
-      disabled={feedback !== null}
+      disabled={feedback !== null || selecting}
     >
       <span className="text-7xl sm:text-8xl md:text-9xl font-extrabold text-white text-shadow-game">
         {value}

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -10,7 +10,10 @@ import { playCorrectSound, playWrongSound } from "@/lib/sounds";
 
 import type { AnswerFeedback } from "./AnswerOption";
 
-type GamePhase = "playing" | "feedback";
+type GamePhase = "playing" | "selecting" | "feedback";
+
+/** Tempo em ms da animação de destaque ao selecionar opção. */
+const SELECTION_DURATION_MS = 400;
 
 /** Tempo em ms que o feedback fica visível antes de avançar. */
 const FEEDBACK_DURATION_MS = 2500;
@@ -24,9 +27,10 @@ const FADE_MS = 300;
  * Fluxo:
  * 1. Exibe questão gerada aleatoriamente
  * 2. Jogador pressiona ← ou → (acionadores)
- * 3. Valida resposta e mostra feedback visual (2,5 s)
- * 4. Fade-out → nova questão → fade-in
- * 5. Repete
+ * 3. Animação de destaque na opção selecionada (~400 ms)
+ * 4. Valida resposta e mostra feedback visual (2,5 s)
+ * 5. Fade-out → nova questão → fade-in
+ * 6. Repete
  */
 export default function GameScreen() {
   const [question, setQuestion] = useState<MathQuestion>(() =>
@@ -83,17 +87,25 @@ export default function GameScreen() {
     (side: "left" | "right") => {
       if (phase !== "playing") return;
 
-      const correct = side === question.correctSide;
+      /* 1. Destaque visual imediato na opção escolhida */
       setSelectedSide(side);
-      setIsCorrect(correct);
-      setPhase("feedback");
+      setPhase("selecting");
 
-      // Feedback sonoro imediato
-      if (correct) {
-        playCorrectSound();
-      } else {
-        playWrongSound();
-      }
+      /* 2. Após a animação de destaque, avalia e mostra feedback */
+      const t = setTimeout(() => {
+        const correct = side === question.correctSide;
+        setIsCorrect(correct);
+        setPhase("feedback");
+
+        // Feedback sonoro junto com o visual de certo/errado
+        if (correct) {
+          playCorrectSound();
+        } else {
+          playWrongSound();
+        }
+      }, SELECTION_DURATION_MS);
+
+      timersRef.current.push(t);
     },
     [phase, question.correctSide]
   );
@@ -147,7 +159,8 @@ export default function GameScreen() {
             <AnswerOption
               value={question.leftValue}
               side="left"
-              selected={phase === "playing" && selectedSide === "left"}
+              selected={selectedSide === "left" && phase === "playing"}
+              selecting={selectedSide === "left" && phase === "selecting"}
               feedback={getFeedback("left")}
               onSelect={() => handleSelect("left")}
             />
@@ -156,7 +169,8 @@ export default function GameScreen() {
             <AnswerOption
               value={question.rightValue}
               side="right"
-              selected={phase === "playing" && selectedSide === "right"}
+              selected={selectedSide === "right" && phase === "playing"}
+              selecting={selectedSide === "right" && phase === "selecting"}
               feedback={getFeedback("right")}
               onSelect={() => handleSelect("right")}
             />


### PR DESCRIPTION
## Descrição

Implementa a **issue #15** — animação visual de destaque quando o jogador pressiona um acionador, antes de mostrar se está certo ou errado.

### O que mudou

**Nova fase `selecting` no fluxo do jogo:**

```
pressionar acionador → selecionando (400 ms) → feedback (2,5 s) → próxima questão
```

**Animação na opção escolhida:**
- 🔍 Scale-up para 110% (transição suave de 300 ms)
- 💛 Anel amarelo (yellow-300) de 8 px — distinto do anel branco de feedback
- ✨ Glow dourado pulsante via CSS `@keyframes` (400 ms, ease-out)
- 🔆 Brilho levemente aumentado (brightness-110)

### Acessibilidade
- ♿ Anel amarelo vs blue-800 = **6,7 : 1** | vs green-800 = **7,2 : 1** — alta visibilidade
- 🗣️ `aria-label` atualizado com estado "selecionando"
- 🔇 Feedback sonoro toca **após** a animação (junto com certo/errado)
- 🖱️ Botão desativado durante a animação para evitar seleção dupla

### Arquivos alterados
- `src/app/globals.css` — keyframes `selection-glow` + classe `.animate-selection-glow`
- `src/components/AnswerOption.tsx` — nova prop `selecting`, lógica de estilo, aria
- `src/components/GameScreen.tsx` — fase `selecting`, timer de 400 ms

Closes #15