### PR TITLE
feat: narração por voz das perguntas e opções (Web Speech API)

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -7,6 +7,7 @@ import FeedbackOverlay from "./FeedbackOverlay";
 import { useSwitch } from "@/hooks/useSwitch";
 import { generateQuestion, type MathQuestion } from "@/lib/generateQuestion";
 import { playCorrectSound, playWrongSound } from "@/lib/sounds";
+import { initSpeech, cancelSpeech, speak, buildNarration } from "@/lib/speech";
 
 import type { AnswerFeedback } from "./AnswerOption";
 
@@ -26,11 +27,13 @@ const FADE_MS = 300;
  *
  * Fluxo:
  * 1. Exibe questão gerada aleatoriamente
- * 2. Jogador pressiona ← ou → (acionadores)
- * 3. Animação de destaque na opção selecionada (~400 ms)
- * 4. Valida resposta e mostra feedback visual (2,5 s)
- * 5. Fade-out → nova questão → fade-in
- * 6. Repete
+ * 2. Narração por voz: "Quanto é X mais Y? À esquerda, A. À direita, B."
+ * 3. Jogador pressiona ← ou → (acionadores)
+ * 4. Narração é cancelada imediatamente
+ * 5. Animação de destaque na opção selecionada (~400 ms)
+ * 6. Valida resposta e mostra feedback visual + sonoro (2,5 s)
+ * 7. Fade-out → nova questão → fade-in → nova narração
+ * 8. Repete
  */
 export default function GameScreen() {
   const [question, setQuestion] = useState<MathQuestion>(() =>
@@ -54,6 +57,30 @@ export default function GameScreen() {
       timersRef.current.forEach(clearTimeout);
     };
   }, []);
+
+  /* ── Inicializa sistema de narração por voz ── */
+  useEffect(() => {
+    initSpeech();
+    return () => {
+      cancelSpeech();
+    };
+  }, []);
+
+  /* ── Narra a pergunta e opções ao exibir cada questão ── */
+  useEffect(() => {
+    if (!visible || phase !== "playing") return;
+
+    const text = buildNarration(
+      question.text,
+      question.leftValue,
+      question.rightValue,
+    );
+    speak(text);
+
+    return () => {
+      cancelSpeech();
+    };
+  }, [question, visible, phase]);
 
   /* ── Avanço automático após feedback ── */
   useEffect(() => {
@@ -86,6 +113,9 @@ export default function GameScreen() {
   const handleSelect = useCallback(
     (side: "left" | "right") => {
       if (phase !== "playing") return;
+
+      /* Cancela narração em andamento para não sobrepor o feedback */
+      cancelSpeech();
 
       /* 1. Destaque visual imediato na opção escolhida */
       setSelectedSide(side);

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -1,0 +1,115 @@
+/**
+ * Narração por voz usando Web Speech API (speechSynthesis).
+ *
+ * Seleciona automaticamente a melhor voz pt-BR disponível
+ * e narra perguntas e opções do jogo de forma natural.
+ *
+ * Chrome é o browser alvo principal.
+ */
+
+let selectedVoice: SpeechSynthesisVoice | null = null;
+let voicesLoaded = false;
+
+/* ── Mapa de operadores para palavras em português ── */
+const OPERATOR_WORDS: Record<string, string> = {
+  "+": "mais",
+  "-": "menos",
+  "×": "vezes",
+  "÷": "dividido por",
+};
+
+/* ── Gestão de vozes ── */
+
+/**
+ * Busca e armazena a melhor voz pt-BR disponível no browser.
+ */
+function loadVoice(): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+
+  const voices = window.speechSynthesis.getVoices();
+  if (voices.length === 0) return;
+
+  // Prioridade: pt-BR exato → qualquer pt-* → primeira disponível
+  selectedVoice =
+    voices.find((v) => v.lang === "pt-BR") ??
+    voices.find((v) => v.lang.startsWith("pt")) ??
+    voices[0];
+
+  voicesLoaded = true;
+}
+
+/**
+ * Inicializa o sistema de voz.
+ * Chame uma vez no lado do cliente (useEffect de montagem).
+ */
+export function initSpeech(): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+
+  loadVoice();
+
+  // Chrome carrega vozes de forma assíncrona — escuta o evento
+  if (!voicesLoaded) {
+    window.speechSynthesis.addEventListener("voiceschanged", loadVoice);
+  }
+}
+
+/* ── Controle de narração ── */
+
+/**
+ * Cancela qualquer narração em andamento.
+ */
+export function cancelSpeech(): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+  window.speechSynthesis.cancel();
+}
+
+/**
+ * Fala o texto em pt-BR usando speechSynthesis.
+ * Cancela automaticamente qualquer narração anterior.
+ *
+ * @param text  Texto para narrar.
+ * @param rate  Velocidade (padrão 0,9 — levemente mais lento para clareza).
+ */
+export function speak(text: string, rate = 0.9): void {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+  if (!text) return;
+
+  cancelSpeech();
+
+  // Tenta carregar voz se ainda não carregou
+  if (!voicesLoaded) loadVoice();
+
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = "pt-BR";
+  utterance.rate = rate;
+  utterance.pitch = 1;
+  utterance.volume = 1;
+
+  if (selectedVoice) {
+    utterance.voice = selectedVoice;
+  }
+
+  window.speechSynthesis.speak(utterance);
+}
+
+/* ── Construção de frases ── */
+
+/**
+ * Constrói a frase de narração para uma questão de matemática.
+ *
+ * Entrada: texto "12 + 15 = ?", leftValue 27, rightValue 30
+ * Saída:   "Quanto é 12 mais 15? À esquerda, 27. À direita, 30."
+ */
+export function buildNarration(
+  questionText: string,
+  leftValue: number | string,
+  rightValue: number | string,
+): string {
+  const match = questionText.match(/^(\d+)\s*([+\-×÷])\s*(\d+)/);
+  if (!match) return "";
+
+  const [, a, op, b] = match;
+  const word = OPERATOR_WORDS[op] ?? op;
+
+  return `Quanto é ${a} ${word} ${b}? À esquerda, ${leftValue}. À direita, ${rightValue}.`;
+}


### PR DESCRIPTION
## Descrição

Implementa a **issue #35** — narração automática por voz de cada pergunta e suas opções em pt-BR usando Web Speech API.

### Exemplo de narração

> "Quanto é 7 vezes 8? À esquerda, 56. À direita, 48."

### O que mudou

**Novo módulo `src/lib/speech.ts`:**
- `initSpeech()` — carrega vozes, seleciona pt-BR automaticamente (pt-BR > pt-* > fallback)
- `speak(text, rate)` — fala texto em pt-BR, cancela narração anterior
- `cancelSpeech()` — para narração imediatamente
- `buildNarration()` — constrói frases naturais para cada operação:
  - `+` → "mais" · `-` → "menos" · `×` → "vezes" · `÷` → "dividido por"

**Alterações em `GameScreen.tsx`:**
- `useEffect` de montagem: inicializa TTS (`initSpeech()`)
- `useEffect` de narração: narra pergunta + opções quando questão aparece (`visible && phase === playing`)
- `handleSelect`: cancela narração ao pressionar acionador → sem sobreposição com sons de acerto/erro

### Detalhes técnicos
- Velocidade: 0.9x (levemente mais lenta para clareza)
- Chrome é o alvo principal; fallback gracioso em browsers sem suporte
- Cleanup adequado nos useEffects (cancela speech no unmount)
- Narração não sobrepõe feedback sonoro (`cancelSpeech()` antes de sons)

Closes #35