### PR TITLE
feat: repetição automática da narração após 15s sem resposta

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -22,6 +22,9 @@ const FEEDBACK_DURATION_MS = 2500;
 /** Tempo em ms da transição de fade entre questões. */
 const FADE_MS = 300;
 
+/** Tempo em ms para repetir a narração se o jogador não responder. */
+const NARRATION_REPEAT_MS = 15_000;
+
 /**
  * Tela principal do jogo.
  *
@@ -33,7 +36,8 @@ const FADE_MS = 300;
  * 5. Animação de destaque na opção selecionada (~400 ms)
  * 6. Valida resposta e mostra feedback visual + sonoro (2,5 s)
  * 7. Fade-out → nova questão → fade-in → nova narração
- * 8. Repete
+ * 8. Se o jogador não responder em 15 s, repete a narração em loop
+ * 9. Repete
  */
 export default function GameScreen() {
   const [question, setQuestion] = useState<MathQuestion>(() =>
@@ -76,6 +80,24 @@ export default function GameScreen() {
 
     return () => {
       cancelSpeech();
+    };
+  }, [question, visible, phase]);
+
+  /* ── Repete narração a cada 15 s sem resposta ── */
+  useEffect(() => {
+    if (!visible || phase !== "playing") return;
+
+    const interval = setInterval(() => {
+      const text = buildNarration(
+        question.text,
+        question.leftValue,
+        question.rightValue,
+      );
+      speak(text);
+    }, NARRATION_REPEAT_MS);
+
+    return () => {
+      clearInterval(interval);
     };
   }, [question, visible, phase]);
 


### PR DESCRIPTION
## Descrição

Implementa a **issue #36** — se o jogador não responder em 15 segundos, a narração da pergunta e opções é repetida automaticamente. Repete em loop até receber resposta.

### Como funciona

- `setInterval` de 15s roda enquanto `phase === "playing" && visible`
- A cada tick, chama `speak(buildNarration(...))` que re-narra a questão
- O interval é limpo automaticamente quando:
  - O jogador responde (phase muda para "selecting")
  - Nova questão aparece (deps do useEffect mudam → cleanup + restart)
  - Componente desmonta

### Checklist da issue
- [x] Timer de 15s que inicia ao exibir cada questão
- [x] Ao expirar, re-narrar pergunta e opções
- [x] Repetir em loop (a cada 15s) até o jogador responder
- [x] Resetar timer ao avançar para nova questão
- [x] Pausar timer durante tela de feedback (acerto/erro)
- [x] Cancelar narração em andamento se jogador responder durante a fala

### Arquivo alterado
- `src/components/GameScreen.tsx` — novo useEffect com setInterval

Closes #36