### PR TITLE
feat: configurações de voz (ligar/desligar, velocidade, volume, repetição)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,12 @@
 import GameScreen from "@/components/GameScreen";
+import { SettingsProvider } from "@/contexts/SettingsContext";
 
 export default function Home() {
   return (
-    <main className="h-full w-full">
-      <GameScreen />
-    </main>
+    <SettingsProvider>
+      <main className="h-full w-full">
+        <GameScreen />
+      </main>
+    </SettingsProvider>
   );
 }

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -4,10 +4,19 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Question from "./Question";
 import AnswerOption from "./AnswerOption";
 import FeedbackOverlay from "./FeedbackOverlay";
+import SettingsScreen from "./SettingsScreen";
 import { useSwitch } from "@/hooks/useSwitch";
+import { useSettings } from "@/contexts/SettingsContext";
 import { generateQuestion, type MathQuestion } from "@/lib/generateQuestion";
 import { playCorrectSound, playWrongSound } from "@/lib/sounds";
-import { initSpeech, cancelSpeech, speak, buildNarration } from "@/lib/speech";
+import {
+  initSpeech,
+  configureSpeech,
+  cancelSpeech,
+  speak,
+  buildNarration,
+} from "@/lib/speech";
+import { VOICE_SPEED_RATES } from "@/lib/settings";
 
 import type { AnswerFeedback } from "./AnswerOption";
 
@@ -22,9 +31,6 @@ const FEEDBACK_DURATION_MS = 2500;
 /** Tempo em ms da transição de fade entre questões. */
 const FADE_MS = 300;
 
-/** Tempo em ms para repetir a narração se o jogador não responder. */
-const NARRATION_REPEAT_MS = 15_000;
-
 /**
  * Tela principal do jogo.
  *
@@ -36,21 +42,26 @@ const NARRATION_REPEAT_MS = 15_000;
  * 5. Animação de destaque na opção selecionada (~400 ms)
  * 6. Valida resposta e mostra feedback visual + sonoro (2,5 s)
  * 7. Fade-out → nova questão → fade-in → nova narração
- * 8. Se o jogador não responder em 15 s, repete a narração em loop
+ * 8. Se o jogador não responder em N segundos, repete a narração em loop
  * 9. Repete
  */
 export default function GameScreen() {
+  const { voice } = useSettings();
+
   const [question, setQuestion] = useState<MathQuestion>(() =>
-    generateQuestion()
+    generateQuestion(),
   );
   const [phase, setPhase] = useState<GamePhase>("playing");
   const [selectedSide, setSelectedSide] = useState<"left" | "right" | null>(
-    null
+    null,
   );
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
   /** Controla a opacidade para transição suave entre questões. */
   const [visible, setVisible] = useState(true);
+
+  /** Mostra/esconde a tela de configurações. */
+  const [showSettings, setShowSettings] = useState(false);
 
   /** Ref para limpar timers no unmount. */
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -67,9 +78,18 @@ export default function GameScreen() {
     return initSpeech();
   }, []);
 
+  /* ── Sincroniza config de voz com o módulo speech.ts ── */
+  useEffect(() => {
+    configureSpeech({
+      enabled: voice.enabled,
+      rate: VOICE_SPEED_RATES[voice.speed],
+      volume: voice.volume,
+    });
+  }, [voice.enabled, voice.speed, voice.volume]);
+
   /* ── Narra a pergunta e opções ao exibir cada questão ── */
   useEffect(() => {
-    if (!visible || phase !== "playing") return;
+    if (!visible || phase !== "playing" || showSettings) return;
 
     const text = buildNarration(
       question.text,
@@ -81,11 +101,12 @@ export default function GameScreen() {
     return () => {
       cancelSpeech();
     };
-  }, [question, visible, phase]);
+  }, [question, visible, phase, showSettings]);
 
-  /* ── Repete narração a cada 15 s sem resposta ── */
+  /* ── Repete narração a cada N segundos sem resposta ── */
   useEffect(() => {
-    if (!visible || phase !== "playing") return;
+    if (!visible || phase !== "playing" || showSettings) return;
+    if (!voice.enabled) return;
 
     const interval = setInterval(() => {
       const text = buildNarration(
@@ -94,12 +115,12 @@ export default function GameScreen() {
         question.rightValue,
       );
       speak(text);
-    }, NARRATION_REPEAT_MS);
+    }, voice.repeatDelay);
 
     return () => {
       clearInterval(interval);
     };
-  }, [question, visible, phase]);
+  }, [question, visible, phase, showSettings, voice.enabled, voice.repeatDelay]);
 
   /* ── Avanço automático após feedback ── */
   useEffect(() => {
@@ -156,10 +177,13 @@ export default function GameScreen() {
 
       timersRef.current.push(t);
     },
-    [phase, question.correctSide]
+    [phase, question.correctSide],
   );
 
-  useSwitch({ onSelect: handleSelect, enabled: phase === "playing" });
+  useSwitch({
+    onSelect: handleSelect,
+    enabled: phase === "playing" && !showSettings,
+  });
 
   /* ── Feedback por opção ── */
   function getFeedback(side: "left" | "right"): AnswerFeedback {
@@ -178,10 +202,26 @@ export default function GameScreen() {
 
   return (
     <div className="relative flex flex-col h-full w-full">
+      {/* ── Overlay de configurações ── */}
+      {showSettings && (
+        <SettingsScreen onClose={() => setShowSettings(false)} />
+      )}
+
       {/* ── Overlay de feedback ── */}
       {phase === "feedback" && isCorrect !== null && (
         <FeedbackOverlay result={isCorrect ? "correct" : "wrong"} />
       )}
+
+      {/* ── Botão de configurações (para cuidador/responsável) ── */}
+      <button
+        className="absolute top-3 right-3 z-40 flex items-center justify-center
+                   w-12 h-12 rounded-full bg-gray-800/70 text-2xl
+                   hover:bg-gray-700 transition-colors"
+        aria-label="Abrir configurações"
+        onClick={() => setShowSettings(true)}
+      >
+        ⚙
+      </button>
 
       {/* ── Conteúdo com transição de opacidade ── */}
       <div

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+/**
+ * Tela de configurações de voz — acessível por acionadores.
+ *
+ * Navegação com 2 acionadores (← →):
+ * - ← (esquerda) : move foco para a próxima configuração
+ * - → (direita)  : altera o valor da configuração focada
+ *                   (ou "Voltar ao jogo" na última opção)
+ *
+ * Alto contraste, texto grande, foco visual amarelo.
+ */
+
+import { useState, useCallback } from "react";
+import { useSwitch } from "@/hooks/useSwitch";
+import { useSettings } from "@/contexts/SettingsContext";
+import type { VoiceSpeed } from "@/lib/settings";
+
+/* ── Opções de cada configuração ── */
+
+const SPEED_OPTIONS: VoiceSpeed[] = ["slow", "normal", "fast"];
+const SPEED_LABELS: Record<VoiceSpeed, string> = {
+  slow: "Lenta",
+  normal: "Normal",
+  fast: "Rápida",
+};
+
+const VOLUME_OPTIONS = [0, 0.25, 0.5, 0.75, 1];
+const VOLUME_LABELS = ["0%", "25%", "50%", "75%", "100%"];
+
+const REPEAT_OPTIONS = [10_000, 15_000, 20_000, 25_000, 30_000];
+const REPEAT_LABELS = ["10s", "15s", "20s", "25s", "30s"];
+
+/* ── Linhas do menu ── */
+
+const ROWS = ["enabled", "speed", "volume", "repeatDelay", "back"] as const;
+type Row = (typeof ROWS)[number];
+
+const ROW_LABELS: Record<Row, string> = {
+  enabled: "Narração",
+  speed: "Velocidade",
+  volume: "Volume",
+  repeatDelay: "Repetição",
+  back: "← Voltar ao jogo",
+};
+
+const ROW_ICONS: Record<Row, string> = {
+  enabled: "🔊",
+  speed: "⏩",
+  volume: "🔈",
+  repeatDelay: "🔄",
+  back: "",
+};
+
+/* ── Componente ── */
+
+interface SettingsScreenProps {
+  onClose: () => void;
+}
+
+export default function SettingsScreen({ onClose }: SettingsScreenProps) {
+  const { voice, updateVoice } = useSettings();
+  const [focusIdx, setFocusIdx] = useState(0);
+
+  /** Retorna o label do valor atual para uma linha. */
+  function currentValueLabel(row: Row): string {
+    switch (row) {
+      case "enabled":
+        return voice.enabled ? "Ligada" : "Desligada";
+      case "speed":
+        return SPEED_LABELS[voice.speed];
+      case "volume": {
+        const idx = VOLUME_OPTIONS.indexOf(voice.volume);
+        return idx !== -1 ? VOLUME_LABELS[idx] : `${Math.round(voice.volume * 100)}%`;
+      }
+      case "repeatDelay": {
+        const idx = REPEAT_OPTIONS.indexOf(voice.repeatDelay);
+        return idx !== -1 ? REPEAT_LABELS[idx] : `${voice.repeatDelay / 1000}s`;
+      }
+      case "back":
+        return "";
+    }
+  }
+
+  /** Avança para o próximo valor da configuração focada. */
+  function cycleValue(row: Row): void {
+    switch (row) {
+      case "enabled":
+        updateVoice({ enabled: !voice.enabled });
+        break;
+      case "speed": {
+        const idx = SPEED_OPTIONS.indexOf(voice.speed);
+        updateVoice({
+          speed: SPEED_OPTIONS[(idx + 1) % SPEED_OPTIONS.length],
+        });
+        break;
+      }
+      case "volume": {
+        const idx = VOLUME_OPTIONS.indexOf(voice.volume);
+        const cur = idx === -1 ? VOLUME_OPTIONS.length - 1 : idx;
+        updateVoice({
+          volume: VOLUME_OPTIONS[(cur + 1) % VOLUME_OPTIONS.length],
+        });
+        break;
+      }
+      case "repeatDelay": {
+        const idx = REPEAT_OPTIONS.indexOf(voice.repeatDelay);
+        const cur = idx === -1 ? 1 : idx;
+        updateVoice({
+          repeatDelay: REPEAT_OPTIONS[(cur + 1) % REPEAT_OPTIONS.length],
+        });
+        break;
+      }
+      case "back":
+        onClose();
+        break;
+    }
+  }
+
+  const handleSelect = useCallback(
+    (side: "left" | "right") => {
+      if (side === "left") {
+        setFocusIdx((prev) => (prev + 1) % ROWS.length);
+      } else {
+        cycleValue(ROWS[focusIdx]);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [focusIdx, voice],
+  );
+
+  useSwitch({ onSelect: handleSelect, enabled: true });
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/95 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Configurações de voz"
+    >
+      {/* Título */}
+      <h2 className="mb-6 text-3xl sm:text-4xl font-bold text-white text-shadow-game">
+        ⚙ Configurações de Voz
+      </h2>
+
+      {/* Lista de opções */}
+      <div className="flex w-full max-w-lg flex-col gap-3">
+        {ROWS.map((row, idx) => {
+          const focused = idx === focusIdx;
+          const isBack = row === "back";
+
+          return (
+            <button
+              key={row}
+              className={`
+                flex items-center justify-between rounded-2xl px-5 py-4
+                text-xl sm:text-2xl font-semibold transition-all duration-200
+                ${
+                  focused
+                    ? "scale-105 ring-4 ring-yellow-300 bg-gray-800 text-white shadow-lg shadow-yellow-300/20"
+                    : "bg-gray-900 text-gray-400"
+                }
+                ${isBack ? "mt-2" : ""}
+              `}
+              aria-label={
+                isBack
+                  ? "Voltar ao jogo"
+                  : `${ROW_LABELS[row]}: ${currentValueLabel(row)}. Pressione direita para alterar.`
+              }
+              aria-current={focused ? "true" : undefined}
+              tabIndex={-1}
+              onClick={() => {
+                setFocusIdx(idx);
+                cycleValue(row);
+              }}
+            >
+              <span className="flex items-center gap-3">
+                {ROW_ICONS[row] && (
+                  <span aria-hidden="true">{ROW_ICONS[row]}</span>
+                )}
+                <span>{ROW_LABELS[row]}</span>
+              </span>
+
+              {!isBack && (
+                <span
+                  className={`
+                    rounded-lg px-3 py-1 text-lg sm:text-xl font-bold
+                    ${focused ? "bg-yellow-300 text-gray-900" : "bg-gray-700 text-gray-300"}
+                  `}
+                >
+                  {currentValueLabel(row)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Instruções */}
+      <p className="mt-6 text-center text-base sm:text-lg text-gray-500">
+        ◀ mover &nbsp;&nbsp; ▶ alterar
+      </p>
+    </div>
+  );
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/**
+ * Contexto global de configurações do jogo.
+ *
+ * Provê acesso reativo às configurações de voz (e futuras
+ * categorias de #14) para todos os componentes filhos.
+ * Persiste automaticamente em localStorage a cada alteração.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import type { VoiceSettings } from "@/lib/settings";
+import {
+  DEFAULT_VOICE_SETTINGS,
+  loadVoiceSettings,
+  saveVoiceSettings,
+} from "@/lib/settings";
+
+interface SettingsContextValue {
+  voice: VoiceSettings;
+  updateVoice: (patch: Partial<VoiceSettings>) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue>({
+  voice: DEFAULT_VOICE_SETTINGS,
+  updateVoice: () => {},
+});
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [voice, setVoice] = useState<VoiceSettings>(DEFAULT_VOICE_SETTINGS);
+
+  /* Carrega do localStorage na montagem (client-side only) */
+  useEffect(() => {
+    setVoice(loadVoiceSettings());
+  }, []);
+
+  const updateVoice = useCallback((patch: Partial<VoiceSettings>) => {
+    setVoice((prev) => {
+      const next = { ...prev, ...patch };
+      saveVoiceSettings(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <SettingsContext.Provider value={{ voice, updateVoice }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,61 @@
+/**
+ * Configurações de voz do jogo.
+ *
+ * Tipos, valores padrão e persistência em localStorage.
+ * Extensível para outras categorias de configuração (#14).
+ */
+
+/* ── Tipos ── */
+
+export type VoiceSpeed = "slow" | "normal" | "fast";
+
+export interface VoiceSettings {
+  /** Narração ativada/desativada. */
+  enabled: boolean;
+  /** Velocidade da fala. */
+  speed: VoiceSpeed;
+  /** Volume da voz (0 a 1). */
+  volume: number;
+  /** Intervalo de repetição em ms (10 000 a 30 000). */
+  repeatDelay: number;
+}
+
+/* ── Constantes ── */
+
+/** Mapa de velocidade → rate do speechSynthesis. */
+export const VOICE_SPEED_RATES: Record<VoiceSpeed, number> = {
+  slow: 0.7,
+  normal: 0.9,
+  fast: 1.1,
+};
+
+export const DEFAULT_VOICE_SETTINGS: VoiceSettings = {
+  enabled: true,
+  speed: "normal",
+  volume: 1,
+  repeatDelay: 15_000,
+};
+
+/* ── Persistência (localStorage) ── */
+
+const STORAGE_KEY = "duo-math-voice-settings";
+
+export function loadVoiceSettings(): VoiceSettings {
+  if (typeof window === "undefined") return DEFAULT_VOICE_SETTINGS;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_VOICE_SETTINGS;
+    return { ...DEFAULT_VOICE_SETTINGS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_VOICE_SETTINGS;
+  }
+}
+
+export function saveVoiceSettings(settings: VoiceSettings): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // localStorage indisponível — falha silenciosa
+  }
+}

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -4,12 +4,17 @@
  * Seleciona automaticamente a melhor voz pt-BR disponível
  * e narra perguntas e opções do jogo de forma natural.
  *
+ * Configurável via `configureSpeech()`:
+ * - enabled: liga/desliga narração
+ * - rate: velocidade da fala (0.1 – 10)
+ * - volume: volume da voz (0 – 1)
+ *
  * Compatibilidade:
  * - Chrome 71+: exige ativação do usuário para o primeiro speak()
  * - Safari iOS: exige gesto do usuário para o primeiro speak()
  * - Chrome: cancel() seguido de speak() pode ser ignorado (fix: delay 50 ms)
  *
- * Estratégia:
+ * Estratégia de desbloqueio:
  * 1. Na montagem, registra listeners para desbloquear no primeiro gesto
  * 2. Antes do desbloqueio, armazena a última narração tentada
  * 3. No primeiro gesto do usuário (click/touch), fala a narração pendente
@@ -19,6 +24,12 @@
 
 let selectedVoice: SpeechSynthesisVoice | null = null;
 let voicesLoaded = false;
+
+/* ── Configuração interna ── */
+
+let speechEnabled = true;
+let speechRate = 0.9;
+let speechVolume = 1;
 
 /** Timer do workaround cancel()+speak() do Chrome. */
 let speakTimer: ReturnType<typeof setTimeout> | null = null;
@@ -31,9 +42,6 @@ let unlocked = false;
 
 /** Texto da narração pendente (bloqueada antes do primeiro gesto). */
 let pendingText: string | null = null;
-
-/** Rate da narração pendente. */
-let pendingRate = 0.9;
 
 /* ── Mapa de operadores para palavras em português ── */
 const OPERATOR_WORDS: Record<string, string> = {
@@ -85,11 +93,10 @@ function onUserGesture(event: Event): void {
   // e handleSelect vai chamar cancelSpeech() logo em seguida.
   if (event.type !== "keydown" && pendingText) {
     const text = pendingText;
-    const rate = pendingRate;
     pendingText = null;
     unlockTimer = setTimeout(() => {
       unlockTimer = null;
-      doSpeak(text, rate);
+      doSpeak(text);
     }, 100);
   } else {
     pendingText = null;
@@ -101,17 +108,19 @@ function onUserGesture(event: Event): void {
 /**
  * Executa a fala de fato, com workaround para o bug
  * cancel()+speak() do Chrome.
+ *
+ * Usa speechRate e speechVolume da configuração atual.
  */
-function doSpeak(text: string, rate: number): void {
+function doSpeak(text: string): void {
   if (typeof window === "undefined" || !window.speechSynthesis) return;
 
   if (!voicesLoaded) loadVoice();
 
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.lang = "pt-BR";
-  utterance.rate = rate;
+  utterance.rate = speechRate;
   utterance.pitch = 1;
-  utterance.volume = 1;
+  utterance.volume = speechVolume;
 
   if (selectedVoice) {
     utterance.voice = selectedVoice;
@@ -127,6 +136,22 @@ function doSpeak(text: string, rate: number): void {
 }
 
 /* ── API pública ── */
+
+/**
+ * Atualiza a configuração interna do módulo de voz.
+ *
+ * Chamado pelo componente sempre que as VoiceSettings mudam.
+ * Não persiste — a persistência é responsabilidade do contexto.
+ */
+export function configureSpeech(config: {
+  enabled?: boolean;
+  rate?: number;
+  volume?: number;
+}): void {
+  if (config.enabled !== undefined) speechEnabled = config.enabled;
+  if (config.rate !== undefined) speechRate = config.rate;
+  if (config.volume !== undefined) speechVolume = config.volume;
+}
 
 /**
  * Inicializa o sistema de voz.
@@ -176,14 +201,16 @@ export function cancelSpeech(): void {
  * Fala o texto em pt-BR.
  * Cancela automaticamente qualquer narração anterior.
  *
+ * Se a narração estiver desativada (configureSpeech), é no-op.
+ *
  * Se speechSynthesis ainda não foi desbloqueado (nenhum gesto do
  * usuário), armazena o texto como pendente — será falado
  * automaticamente no primeiro click/touch.
  *
  * @param text  Texto para narrar.
- * @param rate  Velocidade (padrão 0,9 — levemente mais lento para clareza).
  */
-export function speak(text: string, rate = 0.9): void {
+export function speak(text: string): void {
+  if (!speechEnabled) return;
   if (typeof window === "undefined" || !window.speechSynthesis) return;
   if (!text) return;
 
@@ -201,12 +228,11 @@ export function speak(text: string, rate = 0.9): void {
   if (!unlocked) {
     // Armazena para falar no primeiro gesto do usuário
     pendingText = text;
-    pendingRate = rate;
     return;
   }
 
   pendingText = null;
-  doSpeak(text, rate);
+  doSpeak(text);
 }
 
 /* ── Construção de frases ── */


### PR DESCRIPTION
## Descrição

Implementa a **issue #37** — configurações de voz com persistência em localStorage e tela acessível por acionadores.

### Novos arquivos

| Arquivo | Função |
|---------|--------|
| `src/lib/settings.ts` | Tipos, defaults, read/write localStorage |
| `src/contexts/SettingsContext.tsx` | React context global de settings |
| `src/components/SettingsScreen.tsx` | Tela de config com navegação ← → |

### Alterações

| Arquivo | Mudança |
|---------|---------|
| `src/lib/speech.ts` | Nova `configureSpeech()`, `speak()` respeita enabled/rate/volume |
| `src/components/GameScreen.tsx` | Usa contexto, sync com speech, repeat delay configurável, botão ⚙ |
| `src/app/page.tsx` | Wraps com `SettingsProvider` |

### Configurações disponíveis

| Config | Opções | Padrão |
|--------|--------|--------|
| Narração | Ligada / Desligada | Ligada |
| Velocidade | Lenta (0.7x) / Normal (0.9x) / Rápida (1.1x) | Normal |
| Volume | 0% / 25% / 50% / 75% / 100% | 100% |
| Repetição | 10s / 15s / 20s / 25s / 30s | 15s |

### Navegação (2 acionadores)
- **← esquerda**: move foco para próxima opção
- **→ direita**: altera valor da opção focada
- Última opção "Voltar ao jogo" retorna ao jogo
- Botão ⚙ no canto para o cuidador abrir configs

### Checklist da issue
- [x] Toggle ligar/desligar narração (padrão: ligado)
- [x] Controle de velocidade da fala (lenta / normal / rápida)
- [x] Controle de volume da voz
- [x] Tempo de repetição ajustável (padrão 15s, range: 10s a 30s)
- [x] Salvar preferências no localStorage
- [x] Navegação das configurações por acionadores (esquerda/direita)

Closes #37