### PR TITLE
feat: tela de configurações acessível (fonte, volume, tempo entre questões)

### DIFF
--- a/src/components/AnswerOption.tsx
+++ b/src/components/AnswerOption.tsx
@@ -13,6 +13,8 @@ interface AnswerOptionProps {
   feedback?: AnswerFeedback;
   /** Callback disparado ao clicar ou pressionar o acionador */
   onSelect?: () => void;
+  /** Classes Tailwind de tamanho do texto (vem da config de fonte). */
+  textClass?: string;
 }
 
 /*
@@ -47,6 +49,7 @@ export default function AnswerOption({
   selecting = false,
   feedback = null,
   onSelect,
+  textClass = "text-7xl sm:text-8xl md:text-9xl",
 }: AnswerOptionProps) {
   /* ── Cores por estado ── */
   let colorClass: string;
@@ -84,7 +87,7 @@ export default function AnswerOption({
       onClick={onSelect}
       disabled={feedback !== null || selecting}
     >
-      <span className="text-7xl sm:text-8xl md:text-9xl font-extrabold text-white text-shadow-game">
+      <span className={`${textClass} font-extrabold text-white text-shadow-game`}>
         {value}
       </span>
 

--- a/src/components/FeedbackOverlay.tsx
+++ b/src/components/FeedbackOverlay.tsx
@@ -1,6 +1,8 @@
 interface FeedbackOverlayProps {
   /** Tipo de resultado */
   result: "correct" | "wrong";
+  /** Classes Tailwind de tamanho do emoji (vem da config de fonte). */
+  emojiClass?: string;
 }
 
 /**
@@ -11,7 +13,10 @@ interface FeedbackOverlayProps {
  * Emoji extra-grande com sombra para baixa visão.
  * Opacidade mais forte para contraste claro.
  */
-export default function FeedbackOverlay({ result }: FeedbackOverlayProps) {
+export default function FeedbackOverlay({
+  result,
+  emojiClass = "text-[10rem] sm:text-[14rem] md:text-[16rem]",
+}: FeedbackOverlayProps) {
   const isCorrect = result === "correct";
 
   const bg = isCorrect ? "bg-green-600/40" : "bg-red-600/40";
@@ -26,7 +31,7 @@ export default function FeedbackOverlay({ result }: FeedbackOverlayProps) {
       aria-live="assertive"
       aria-label={label}
     >
-      <span className="text-[10rem] sm:text-[14rem] md:text-[16rem] drop-shadow-2xl animate-bounce">
+      <span className={`${emojiClass} drop-shadow-2xl animate-bounce`}>
         {emoji}
       </span>
     </div>

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -8,7 +8,7 @@ import SettingsScreen from "./SettingsScreen";
 import { useSwitch } from "@/hooks/useSwitch";
 import { useSettings } from "@/contexts/SettingsContext";
 import { generateQuestion, type MathQuestion } from "@/lib/generateQuestion";
-import { playCorrectSound, playWrongSound } from "@/lib/sounds";
+import { playCorrectSound, playWrongSound, configureSoundVolume } from "@/lib/sounds";
 import {
   initSpeech,
   configureSpeech,
@@ -16,7 +16,12 @@ import {
   speak,
   buildNarration,
 } from "@/lib/speech";
-import { VOICE_SPEED_RATES } from "@/lib/settings";
+import {
+  VOICE_SPEED_RATES,
+  QUESTION_TEXT_CLASSES,
+  ANSWER_TEXT_CLASSES,
+  FEEDBACK_EMOJI_CLASSES,
+} from "@/lib/settings";
 
 import type { AnswerFeedback } from "./AnswerOption";
 
@@ -24,9 +29,6 @@ type GamePhase = "playing" | "selecting" | "feedback";
 
 /** Tempo em ms da animação de destaque ao selecionar opção. */
 const SELECTION_DURATION_MS = 400;
-
-/** Tempo em ms que o feedback fica visível antes de avançar. */
-const FEEDBACK_DURATION_MS = 2500;
 
 /** Tempo em ms da transição de fade entre questões. */
 const FADE_MS = 300;
@@ -40,13 +42,13 @@ const FADE_MS = 300;
  * 3. Jogador pressiona ← ou → (acionadores)
  * 4. Narração é cancelada imediatamente
  * 5. Animação de destaque na opção selecionada (~400 ms)
- * 6. Valida resposta e mostra feedback visual + sonoro (2,5 s)
+ * 6. Valida resposta e mostra feedback visual + sonoro
  * 7. Fade-out → nova questão → fade-in → nova narração
  * 8. Se o jogador não responder em N segundos, repete a narração em loop
  * 9. Repete
  */
 export default function GameScreen() {
-  const { voice } = useSettings();
+  const { voice, game } = useSettings();
 
   const [question, setQuestion] = useState<MathQuestion>(() =>
     generateQuestion(),
@@ -65,6 +67,11 @@ export default function GameScreen() {
 
   /** Ref para limpar timers no unmount. */
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  /* ── Classes de tamanho de fonte (derivadas da config) ── */
+  const questionTextClass = QUESTION_TEXT_CLASSES[game.fontSize];
+  const answerTextClass = ANSWER_TEXT_CLASSES[game.fontSize];
+  const feedbackEmojiClass = FEEDBACK_EMOJI_CLASSES[game.fontSize];
 
   /* ── Limpa timers ao desmontar ── */
   useEffect(() => {
@@ -86,6 +93,11 @@ export default function GameScreen() {
       volume: voice.volume,
     });
   }, [voice.enabled, voice.speed, voice.volume]);
+
+  /* ── Sincroniza volume dos efeitos sonoros ── */
+  useEffect(() => {
+    configureSoundVolume(game.soundVolume);
+  }, [game.soundVolume]);
 
   /* ── Narra a pergunta e opções ao exibir cada questão ── */
   useEffect(() => {
@@ -126,7 +138,7 @@ export default function GameScreen() {
   useEffect(() => {
     if (phase !== "feedback") return;
 
-    // Após FEEDBACK_DURATION_MS, inicia o fade-out
+    // Após o tempo configurado, inicia o fade-out
     const t1 = setTimeout(() => {
       setVisible(false);
 
@@ -140,14 +152,14 @@ export default function GameScreen() {
       }, FADE_MS);
 
       timersRef.current.push(t2);
-    }, FEEDBACK_DURATION_MS);
+    }, game.questionDelay);
 
     timersRef.current.push(t1);
 
     return () => {
       clearTimeout(t1);
     };
-  }, [phase]);
+  }, [phase, game.questionDelay]);
 
   /* ── Seleção de resposta ── */
   const handleSelect = useCallback(
@@ -209,7 +221,10 @@ export default function GameScreen() {
 
       {/* ── Overlay de feedback ── */}
       {phase === "feedback" && isCorrect !== null && (
-        <FeedbackOverlay result={isCorrect ? "correct" : "wrong"} />
+        <FeedbackOverlay
+          result={isCorrect ? "correct" : "wrong"}
+          emojiClass={feedbackEmojiClass}
+        />
       )}
 
       {/* ── Botão de configurações (para cuidador/responsável) ── */}
@@ -236,7 +251,7 @@ export default function GameScreen() {
           className="flex flex-[2] items-center justify-center px-6"
           aria-label="Pergunta"
         >
-          <Question text={question.text} />
+          <Question text={question.text} textClass={questionTextClass} />
         </section>
 
         {/* ── Opções de resposta ── */}
@@ -252,6 +267,7 @@ export default function GameScreen() {
               selecting={selectedSide === "left" && phase === "selecting"}
               feedback={getFeedback("left")}
               onSelect={() => handleSelect("left")}
+              textClass={answerTextClass}
             />
           </div>
           <div className="flex-1 min-w-0">
@@ -262,6 +278,7 @@ export default function GameScreen() {
               selecting={selectedSide === "right" && phase === "selecting"}
               feedback={getFeedback("right")}
               onSelect={() => handleSelect("right")}
+              textClass={answerTextClass}
             />
           </div>
         </section>

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -1,6 +1,8 @@
 interface QuestionProps {
   /** Texto da pergunta, ex: "12 + 15 = ?" */
   text: string;
+  /** Classes Tailwind de tamanho do texto (vem da config de fonte). */
+  textClass?: string;
 }
 
 /**
@@ -8,11 +10,17 @@ interface QuestionProps {
  * Fonte extra-grande com sombra de texto para
  * acessibilidade em baixa visão (WCAG AAA).
  *
- * Tamanhos: 72 px → 96 px → 128 px (min 48 px ✅).
+ * Tamanho padrão (M): 72 px → 96 px → 128 px (min 48 px ✅).
+ * Configurável via prop `textClass` (tamanhos P, M, G, GG).
  */
-export default function Question({ text }: QuestionProps) {
+export default function Question({
+  text,
+  textClass = "text-7xl sm:text-8xl md:text-9xl",
+}: QuestionProps) {
   return (
-    <h1 className="text-7xl sm:text-8xl md:text-9xl font-extrabold text-white text-center leading-tight select-none text-shadow-game">
+    <h1
+      className={`${textClass} font-extrabold text-white text-center leading-tight select-none text-shadow-game`}
+    >
       {text}
     </h1>
   );

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 /**
- * Tela de configurações de voz — acessível por acionadores.
+ * Tela de configurações — acessível por acionadores.
+ *
+ * Agrupa configurações de Jogo e de Voz em seções visuais.
  *
  * Navegação com 2 acionadores (← →):
  * - ← (esquerda) : move foco para a próxima configuração
@@ -14,9 +16,29 @@
 import { useState, useCallback } from "react";
 import { useSwitch } from "@/hooks/useSwitch";
 import { useSettings } from "@/contexts/SettingsContext";
-import type { VoiceSpeed } from "@/lib/settings";
+import type { VoiceSpeed, FontSize } from "@/lib/settings";
 
-/* ── Opções de cada configuração ── */
+/* ══════════════════════════════════════════════
+ * Opções de cada configuração
+ * ══════════════════════════════════════════════ */
+
+/* ── Jogo ── */
+
+const FONT_SIZE_OPTIONS: FontSize[] = ["small", "medium", "large", "xlarge"];
+const FONT_SIZE_LABELS: Record<FontSize, string> = {
+  small: "P",
+  medium: "M",
+  large: "G",
+  xlarge: "GG",
+};
+
+const SOUND_VOL_OPTIONS = [0, 0.5, 1];
+const SOUND_VOL_LABELS = ["0%", "50%", "100%"];
+
+const QUESTION_DELAY_OPTIONS = [1_000, 2_000, 3_000, 5_000];
+const QUESTION_DELAY_LABELS = ["1s", "2s", "3s", "5s"];
+
+/* ── Voz ── */
 
 const SPEED_OPTIONS: VoiceSpeed[] = ["slow", "normal", "fast"];
 const SPEED_LABELS: Record<VoiceSpeed, string> = {
@@ -25,89 +47,155 @@ const SPEED_LABELS: Record<VoiceSpeed, string> = {
   fast: "Rápida",
 };
 
-const VOLUME_OPTIONS = [0, 0.25, 0.5, 0.75, 1];
-const VOLUME_LABELS = ["0%", "25%", "50%", "75%", "100%"];
+const VOICE_VOL_OPTIONS = [0, 0.25, 0.5, 0.75, 1];
+const VOICE_VOL_LABELS = ["0%", "25%", "50%", "75%", "100%"];
 
 const REPEAT_OPTIONS = [10_000, 15_000, 20_000, 25_000, 30_000];
 const REPEAT_LABELS = ["10s", "15s", "20s", "25s", "30s"];
 
-/* ── Linhas do menu ── */
+/* ══════════════════════════════════════════════
+ * Definição das linhas do menu
+ * ══════════════════════════════════════════════ */
 
-const ROWS = ["enabled", "speed", "volume", "repeatDelay", "back"] as const;
-type Row = (typeof ROWS)[number];
+/**
+ * Cada item possui um `id` único.
+ * Items com `section` exibem um cabeçalho de seção acima deles.
+ * Items com `type: "back"` fecham o painel.
+ */
+interface RowDef {
+  id: string;
+  label: string;
+  icon: string;
+  section?: string;
+  type?: "back";
+}
 
-const ROW_LABELS: Record<Row, string> = {
-  enabled: "Narração",
-  speed: "Velocidade",
-  volume: "Volume",
-  repeatDelay: "Repetição",
-  back: "← Voltar ao jogo",
-};
+const ROWS: RowDef[] = [
+  /* ── Jogo ── */
+  { id: "fontSize", label: "Fonte", icon: "📐", section: "Jogo" },
+  { id: "soundVolume", label: "Som", icon: "🔉" },
+  { id: "questionDelay", label: "Tempo", icon: "⏱" },
+  /* ── Voz ── */
+  { id: "voiceEnabled", label: "Narração", icon: "🔊", section: "Voz" },
+  { id: "voiceSpeed", label: "Velocidade", icon: "⏩" },
+  { id: "voiceVolume", label: "Volume voz", icon: "🔈" },
+  { id: "voiceRepeat", label: "Repetição", icon: "🔄" },
+  /* ── Voltar ── */
+  { id: "back", label: "← Voltar ao jogo", icon: "", type: "back" },
+];
 
-const ROW_ICONS: Record<Row, string> = {
-  enabled: "🔊",
-  speed: "⏩",
-  volume: "🔈",
-  repeatDelay: "🔄",
-  back: "",
-};
-
-/* ── Componente ── */
+/* ══════════════════════════════════════════════
+ * Componente
+ * ══════════════════════════════════════════════ */
 
 interface SettingsScreenProps {
   onClose: () => void;
 }
 
 export default function SettingsScreen({ onClose }: SettingsScreenProps) {
-  const { voice, updateVoice } = useSettings();
+  const { voice, updateVoice, game, updateGame } = useSettings();
   const [focusIdx, setFocusIdx] = useState(0);
 
-  /** Retorna o label do valor atual para uma linha. */
-  function currentValueLabel(row: Row): string {
-    switch (row) {
-      case "enabled":
+  /* ── Helpers: label do valor atual ── */
+
+  function currentValueLabel(id: string): string {
+    switch (id) {
+      /* Jogo */
+      case "fontSize":
+        return FONT_SIZE_LABELS[game.fontSize];
+      case "soundVolume": {
+        const idx = SOUND_VOL_OPTIONS.indexOf(game.soundVolume);
+        return idx !== -1
+          ? SOUND_VOL_LABELS[idx]
+          : `${Math.round(game.soundVolume * 100)}%`;
+      }
+      case "questionDelay": {
+        const idx = QUESTION_DELAY_OPTIONS.indexOf(game.questionDelay);
+        return idx !== -1
+          ? QUESTION_DELAY_LABELS[idx]
+          : `${game.questionDelay / 1000}s`;
+      }
+      /* Voz */
+      case "voiceEnabled":
         return voice.enabled ? "Ligada" : "Desligada";
-      case "speed":
+      case "voiceSpeed":
         return SPEED_LABELS[voice.speed];
-      case "volume": {
-        const idx = VOLUME_OPTIONS.indexOf(voice.volume);
-        return idx !== -1 ? VOLUME_LABELS[idx] : `${Math.round(voice.volume * 100)}%`;
+      case "voiceVolume": {
+        const idx = VOICE_VOL_OPTIONS.indexOf(voice.volume);
+        return idx !== -1
+          ? VOICE_VOL_LABELS[idx]
+          : `${Math.round(voice.volume * 100)}%`;
       }
-      case "repeatDelay": {
+      case "voiceRepeat": {
         const idx = REPEAT_OPTIONS.indexOf(voice.repeatDelay);
-        return idx !== -1 ? REPEAT_LABELS[idx] : `${voice.repeatDelay / 1000}s`;
+        return idx !== -1
+          ? REPEAT_LABELS[idx]
+          : `${voice.repeatDelay / 1000}s`;
       }
-      case "back":
+      default:
         return "";
     }
   }
 
-  /** Avança para o próximo valor da configuração focada. */
-  function cycleValue(row: Row): void {
-    switch (row) {
-      case "enabled":
+  /* ── Helpers: avançar valor ── */
+
+  function cycleValue(id: string): void {
+    switch (id) {
+      /* Jogo */
+      case "fontSize": {
+        const idx = FONT_SIZE_OPTIONS.indexOf(game.fontSize);
+        updateGame({
+          fontSize:
+            FONT_SIZE_OPTIONS[(idx + 1) % FONT_SIZE_OPTIONS.length],
+        });
+        break;
+      }
+      case "soundVolume": {
+        const idx = SOUND_VOL_OPTIONS.indexOf(game.soundVolume);
+        const cur = idx === -1 ? SOUND_VOL_OPTIONS.length - 1 : idx;
+        updateGame({
+          soundVolume:
+            SOUND_VOL_OPTIONS[(cur + 1) % SOUND_VOL_OPTIONS.length],
+        });
+        break;
+      }
+      case "questionDelay": {
+        const idx = QUESTION_DELAY_OPTIONS.indexOf(game.questionDelay);
+        const cur = idx === -1 ? 2 : idx; // default pos = 3 s
+        updateGame({
+          questionDelay:
+            QUESTION_DELAY_OPTIONS[
+              (cur + 1) % QUESTION_DELAY_OPTIONS.length
+            ],
+        });
+        break;
+      }
+      /* Voz */
+      case "voiceEnabled":
         updateVoice({ enabled: !voice.enabled });
         break;
-      case "speed": {
+      case "voiceSpeed": {
         const idx = SPEED_OPTIONS.indexOf(voice.speed);
         updateVoice({
           speed: SPEED_OPTIONS[(idx + 1) % SPEED_OPTIONS.length],
         });
         break;
       }
-      case "volume": {
-        const idx = VOLUME_OPTIONS.indexOf(voice.volume);
-        const cur = idx === -1 ? VOLUME_OPTIONS.length - 1 : idx;
+      case "voiceVolume": {
+        const idx = VOICE_VOL_OPTIONS.indexOf(voice.volume);
+        const cur = idx === -1 ? VOICE_VOL_OPTIONS.length - 1 : idx;
         updateVoice({
-          volume: VOLUME_OPTIONS[(cur + 1) % VOLUME_OPTIONS.length],
+          volume:
+            VOICE_VOL_OPTIONS[(cur + 1) % VOICE_VOL_OPTIONS.length],
         });
         break;
       }
-      case "repeatDelay": {
+      case "voiceRepeat": {
         const idx = REPEAT_OPTIONS.indexOf(voice.repeatDelay);
         const cur = idx === -1 ? 1 : idx;
         updateVoice({
-          repeatDelay: REPEAT_OPTIONS[(cur + 1) % REPEAT_OPTIONS.length],
+          repeatDelay:
+            REPEAT_OPTIONS[(cur + 1) % REPEAT_OPTIONS.length],
         });
         break;
       }
@@ -117,87 +205,104 @@ export default function SettingsScreen({ onClose }: SettingsScreenProps) {
     }
   }
 
+  /* ── Navegação por acionadores ── */
+
   const handleSelect = useCallback(
     (side: "left" | "right") => {
       if (side === "left") {
         setFocusIdx((prev) => (prev + 1) % ROWS.length);
       } else {
-        cycleValue(ROWS[focusIdx]);
+        cycleValue(ROWS[focusIdx].id);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [focusIdx, voice],
+    [focusIdx, voice, game],
   );
 
   useSwitch({ onSelect: handleSelect, enabled: true });
 
+  /* ── Renderização ── */
+
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/95 px-4"
+      className="fixed inset-0 z-50 flex flex-col items-center bg-black/95 px-4 py-6 overflow-y-auto"
       role="dialog"
       aria-modal="true"
-      aria-label="Configurações de voz"
+      aria-label="Configurações"
     >
       {/* Título */}
-      <h2 className="mb-6 text-3xl sm:text-4xl font-bold text-white text-shadow-game">
-        ⚙ Configurações de Voz
+      <h2 className="mb-4 text-3xl sm:text-4xl font-bold text-white text-shadow-game">
+        ⚙ Configurações
       </h2>
 
       {/* Lista de opções */}
-      <div className="flex w-full max-w-lg flex-col gap-3">
+      <div className="flex w-full max-w-lg flex-col gap-2">
         {ROWS.map((row, idx) => {
           const focused = idx === focusIdx;
-          const isBack = row === "back";
+          const isBack = row.type === "back";
+          const valueLabel = currentValueLabel(row.id);
 
           return (
-            <button
-              key={row}
-              className={`
-                flex items-center justify-between rounded-2xl px-5 py-4
-                text-xl sm:text-2xl font-semibold transition-all duration-200
-                ${
-                  focused
-                    ? "scale-105 ring-4 ring-yellow-300 bg-gray-800 text-white shadow-lg shadow-yellow-300/20"
-                    : "bg-gray-900 text-gray-400"
-                }
-                ${isBack ? "mt-2" : ""}
-              `}
-              aria-label={
-                isBack
-                  ? "Voltar ao jogo"
-                  : `${ROW_LABELS[row]}: ${currentValueLabel(row)}. Pressione direita para alterar.`
-              }
-              aria-current={focused ? "true" : undefined}
-              tabIndex={-1}
-              onClick={() => {
-                setFocusIdx(idx);
-                cycleValue(row);
-              }}
-            >
-              <span className="flex items-center gap-3">
-                {ROW_ICONS[row] && (
-                  <span aria-hidden="true">{ROW_ICONS[row]}</span>
-                )}
-                <span>{ROW_LABELS[row]}</span>
-              </span>
-
-              {!isBack && (
-                <span
-                  className={`
-                    rounded-lg px-3 py-1 text-lg sm:text-xl font-bold
-                    ${focused ? "bg-yellow-300 text-gray-900" : "bg-gray-700 text-gray-300"}
-                  `}
-                >
-                  {currentValueLabel(row)}
-                </span>
+            <div key={row.id}>
+              {/* Cabeçalho de seção */}
+              {row.section && (
+                <p className="mt-3 mb-1 px-2 text-sm font-bold uppercase tracking-widest text-gray-500">
+                  ── {row.section} ──
+                </p>
               )}
-            </button>
+
+              <button
+                className={`
+                  flex w-full items-center justify-between rounded-2xl px-5 py-3
+                  text-lg sm:text-xl font-semibold transition-all duration-200
+                  ${
+                    focused
+                      ? "scale-105 ring-4 ring-yellow-300 bg-gray-800 text-white shadow-lg shadow-yellow-300/20"
+                      : "bg-gray-900 text-gray-400"
+                  }
+                  ${isBack ? "mt-3" : ""}
+                `}
+                aria-label={
+                  isBack
+                    ? "Voltar ao jogo"
+                    : `${row.label}: ${valueLabel}. Pressione direita para alterar.`
+                }
+                aria-current={focused ? "true" : undefined}
+                tabIndex={-1}
+                onClick={() => {
+                  setFocusIdx(idx);
+                  cycleValue(row.id);
+                }}
+              >
+                <span className="flex items-center gap-3">
+                  {row.icon && (
+                    <span aria-hidden="true">{row.icon}</span>
+                  )}
+                  <span>{row.label}</span>
+                </span>
+
+                {!isBack && (
+                  <span
+                    className={`
+                      rounded-lg px-3 py-1 text-base sm:text-lg font-bold
+                      ${
+                        focused
+                          ? "bg-yellow-300 text-gray-900"
+                          : "bg-gray-700 text-gray-300"
+                      }
+                    `}
+                  >
+                    {valueLabel}
+                  </span>
+                )}
+              </button>
+            </div>
           );
         })}
       </div>
 
       {/* Instruções */}
-      <p className="mt-6 text-center text-base sm:text-lg text-gray-500">
+      <p className="mt-5 text-center text-base sm:text-lg text-gray-500">
         ◀ mover &nbsp;&nbsp; ▶ alterar
       </p>
     </div>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -3,8 +3,8 @@
 /**
  * Contexto global de configurações do jogo.
  *
- * Provê acesso reativo às configurações de voz (e futuras
- * categorias de #14) para todos os componentes filhos.
+ * Provê acesso reativo às configurações de voz e de jogo
+ * para todos os componentes filhos.
  * Persiste automaticamente em localStorage a cada alteração.
  */
 
@@ -15,29 +15,38 @@ import {
   useEffect,
   useState,
 } from "react";
-import type { VoiceSettings } from "@/lib/settings";
+import type { VoiceSettings, GameSettings } from "@/lib/settings";
 import {
   DEFAULT_VOICE_SETTINGS,
   loadVoiceSettings,
   saveVoiceSettings,
+  DEFAULT_GAME_SETTINGS,
+  loadGameSettings,
+  saveGameSettings,
 } from "@/lib/settings";
 
 interface SettingsContextValue {
   voice: VoiceSettings;
   updateVoice: (patch: Partial<VoiceSettings>) => void;
+  game: GameSettings;
+  updateGame: (patch: Partial<GameSettings>) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue>({
   voice: DEFAULT_VOICE_SETTINGS,
   updateVoice: () => {},
+  game: DEFAULT_GAME_SETTINGS,
+  updateGame: () => {},
 });
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [voice, setVoice] = useState<VoiceSettings>(DEFAULT_VOICE_SETTINGS);
+  const [game, setGame] = useState<GameSettings>(DEFAULT_GAME_SETTINGS);
 
   /* Carrega do localStorage na montagem (client-side only) */
   useEffect(() => {
     setVoice(loadVoiceSettings());
+    setGame(loadGameSettings());
   }, []);
 
   const updateVoice = useCallback((patch: Partial<VoiceSettings>) => {
@@ -48,8 +57,16 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const updateGame = useCallback((patch: Partial<GameSettings>) => {
+    setGame((prev) => {
+      const next = { ...prev, ...patch };
+      saveGameSettings(next);
+      return next;
+    });
+  }, []);
+
   return (
-    <SettingsContext.Provider value={{ voice, updateVoice }}>
+    <SettingsContext.Provider value={{ voice, updateVoice, game, updateGame }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,11 +1,13 @@
 /**
- * Configurações de voz do jogo.
+ * Configurações do jogo: voz + jogo.
  *
- * Tipos, valores padrão e persistência em localStorage.
- * Extensível para outras categorias de configuração (#14).
+ * Tipos, valores padrão, persistência em localStorage
+ * e mapeamentos de classes CSS para tamanho de fonte.
  */
 
-/* ── Tipos ── */
+/* ═══════════════════════════════════════════════════════
+ * Configurações de VOZ (#37)
+ * ═══════════════════════════════════════════════════════ */
 
 export type VoiceSpeed = "slow" | "normal" | "fast";
 
@@ -19,8 +21,6 @@ export interface VoiceSettings {
   /** Intervalo de repetição em ms (10 000 a 30 000). */
   repeatDelay: number;
 }
-
-/* ── Constantes ── */
 
 /** Mapa de velocidade → rate do speechSynthesis. */
 export const VOICE_SPEED_RATES: Record<VoiceSpeed, number> = {
@@ -36,14 +36,12 @@ export const DEFAULT_VOICE_SETTINGS: VoiceSettings = {
   repeatDelay: 15_000,
 };
 
-/* ── Persistência (localStorage) ── */
-
-const STORAGE_KEY = "duo-math-voice-settings";
+const VOICE_STORAGE_KEY = "duo-math-voice-settings";
 
 export function loadVoiceSettings(): VoiceSettings {
   if (typeof window === "undefined") return DEFAULT_VOICE_SETTINGS;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(VOICE_STORAGE_KEY);
     if (!raw) return DEFAULT_VOICE_SETTINGS;
     return { ...DEFAULT_VOICE_SETTINGS, ...JSON.parse(raw) };
   } catch {
@@ -54,8 +52,86 @@ export function loadVoiceSettings(): VoiceSettings {
 export function saveVoiceSettings(settings: VoiceSettings): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    localStorage.setItem(VOICE_STORAGE_KEY, JSON.stringify(settings));
   } catch {
     // localStorage indisponível — falha silenciosa
   }
 }
+
+/* ═══════════════════════════════════════════════════════
+ * Configurações do JOGO (#14)
+ * ═══════════════════════════════════════════════════════ */
+
+export type FontSize = "small" | "medium" | "large" | "xlarge";
+
+export interface GameSettings {
+  /** Tamanho da fonte: P, M, G, GG. */
+  fontSize: FontSize;
+  /** Volume dos sons de feedback (0 – 1). */
+  soundVolume: number;
+  /** Tempo de exibição do feedback antes da próxima questão (ms). */
+  questionDelay: number;
+}
+
+export const DEFAULT_GAME_SETTINGS: GameSettings = {
+  fontSize: "medium",
+  soundVolume: 1,
+  questionDelay: 3_000,
+};
+
+const GAME_STORAGE_KEY = "duo-math-game-settings";
+
+export function loadGameSettings(): GameSettings {
+  if (typeof window === "undefined") return DEFAULT_GAME_SETTINGS;
+  try {
+    const raw = localStorage.getItem(GAME_STORAGE_KEY);
+    if (!raw) return DEFAULT_GAME_SETTINGS;
+    return { ...DEFAULT_GAME_SETTINGS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_GAME_SETTINGS;
+  }
+}
+
+export function saveGameSettings(settings: GameSettings): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(GAME_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // localStorage indisponível — falha silenciosa
+  }
+}
+
+/* ── Mapeamentos de tamanho de fonte → classes Tailwind ── */
+
+/**
+ * Classes para o texto da pergunta (Question).
+ * Base (M): text-7xl sm:text-8xl md:text-9xl  (~4.5 rem → 8 rem)
+ */
+export const QUESTION_TEXT_CLASSES: Record<FontSize, string> = {
+  small: "text-5xl sm:text-6xl md:text-7xl",
+  medium: "text-7xl sm:text-8xl md:text-9xl",
+  large: "text-8xl sm:text-9xl md:text-[11rem]",
+  xlarge: "text-[7rem] sm:text-[10rem] md:text-[13rem]",
+};
+
+/**
+ * Classes para os valores das opções de resposta (AnswerOption).
+ * Base (M): text-7xl sm:text-8xl md:text-9xl
+ */
+export const ANSWER_TEXT_CLASSES: Record<FontSize, string> = {
+  small: "text-5xl sm:text-6xl md:text-7xl",
+  medium: "text-7xl sm:text-8xl md:text-9xl",
+  large: "text-8xl sm:text-9xl md:text-[11rem]",
+  xlarge: "text-[7rem] sm:text-[10rem] md:text-[13rem]",
+};
+
+/**
+ * Classes para o emoji do overlay de feedback (FeedbackOverlay).
+ * Base (M): text-[10rem] sm:text-[14rem] md:text-[16rem]
+ */
+export const FEEDBACK_EMOJI_CLASSES: Record<FontSize, string> = {
+  small: "text-[7rem] sm:text-[10rem] md:text-[12rem]",
+  medium: "text-[10rem] sm:text-[14rem] md:text-[16rem]",
+  large: "text-[12rem] sm:text-[16rem] md:text-[18rem]",
+  xlarge: "text-[14rem] sm:text-[18rem] md:text-[20rem]",
+};

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -7,9 +7,22 @@
  * Sons curtos (< 1 segundo) e não punitivos:
  * - Acerto: duas notas ascendentes (C5 → E5), alegre
  * - Erro: "boop" suave descendente, neutro
+ *
+ * Volume configurável via `configureSoundVolume()`.
  */
 
 let audioCtx: AudioContext | null = null;
+
+/** Volume global dos efeitos sonoros (0 – 1). */
+let soundVolume = 1;
+
+/**
+ * Atualiza o volume global dos efeitos sonoros.
+ * Chamado pelo GameScreen quando a configuração muda.
+ */
+export function configureSoundVolume(vol: number): void {
+  soundVolume = Math.max(0, Math.min(1, vol));
+}
 
 /**
  * Retorna o AudioContext singleton (lazy init).
@@ -40,10 +53,13 @@ function getContext(): AudioContext | null {
  * Alegre e positivo. ~0,5 s.
  */
 export function playCorrectSound(): void {
+  if (soundVolume === 0) return;
+
   const ctx = getContext();
   if (!ctx) return;
 
   const now = ctx.currentTime;
+  const vol = soundVolume;
 
   // Nota 1: C5 (523 Hz)
   const osc1 = ctx.createOscillator();
@@ -51,7 +67,7 @@ export function playCorrectSound(): void {
   osc1.type = "sine";
   osc1.frequency.value = 523.25;
   gain1.gain.setValueAtTime(0, now);
-  gain1.gain.linearRampToValueAtTime(0.3, now + 0.02);
+  gain1.gain.linearRampToValueAtTime(0.3 * vol, now + 0.02);
   gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
   osc1.connect(gain1);
   gain1.connect(ctx.destination);
@@ -64,7 +80,7 @@ export function playCorrectSound(): void {
   osc2.type = "sine";
   osc2.frequency.value = 659.26;
   gain2.gain.setValueAtTime(0, now + 0.12);
-  gain2.gain.linearRampToValueAtTime(0.3, now + 0.14);
+  gain2.gain.linearRampToValueAtTime(0.3 * vol, now + 0.14);
   gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
   osc2.connect(gain2);
   gain2.connect(ctx.destination);
@@ -77,10 +93,13 @@ export function playCorrectSound(): void {
  * Neutro e gentil, não punitivo. ~0,35 s.
  */
 export function playWrongSound(): void {
+  if (soundVolume === 0) return;
+
   const ctx = getContext();
   if (!ctx) return;
 
   const now = ctx.currentTime;
+  const vol = soundVolume;
 
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
@@ -88,7 +107,7 @@ export function playWrongSound(): void {
   osc.frequency.setValueAtTime(260, now);
   osc.frequency.linearRampToValueAtTime(200, now + 0.3);
   gain.gain.setValueAtTime(0, now);
-  gain.gain.linearRampToValueAtTime(0.25, now + 0.02);
+  gain.gain.linearRampToValueAtTime(0.25 * vol, now + 0.02);
   gain.gain.exponentialRampToValueAtTime(0.001, now + 0.35);
   osc.connect(gain);
   gain.connect(ctx.destination);


### PR DESCRIPTION
## Descrição

Implementa a **issue #14** — última issue da fase 3. Estende o sistema de configurações (#37) com settings de jogo.

### Novas configurações de jogo

| Config | Opções | Padrão |
|--------|--------|--------|
| Fonte | P / M / G / GG | M |
| Som | 0% / 50% / 100% | 100% |
| Tempo entre questões | 1s / 2s / 3s / 5s | 3s |

### Tela unificada de configurações

A tela agora agrupa **Jogo** e **Voz** em seções visuais:
- ← mover entre opções
- → alterar valor
- Tudo salvo em localStorage

### Arquivos alterados (8)

| Arquivo | Mudança |
|---------|---------|
|  |  type + mapeamentos de classes Tailwind |
|  |  +  no contexto |
|  | Seções Jogo/Voz com 7 configs + Voltar |
|  |  — gain × volume |
|  | Prop  para tamanho configurável |
|  | Prop  para tamanho configurável |
|  | Prop  para tamanho configurável |
|  | Usa , classes de fonte,  |

### Checklist da issue
- [x] Criar página de configurações
- [x] Opção: tamanho da fonte (P, M, G, GG)
- [x] Opção: volume dos sons (0%, 50%, 100%)
- [x] Opção: tempo entre questões (1s, 2s, 3s, 5s)
- [x] Navegação acessível (acionadores para navegar e selecionar)
- [x] Salvar preferências no localStorage

Closes #14