### PR TITLE
feat: conteúdos BNCC do 1º ao 3º ano (Fundamental 1 inicial)

### DIFF
--- a/src/lib/__tests__/generateQuestion.test.ts
+++ b/src/lib/__tests__/generateQuestion.test.ts
@@ -18,6 +18,15 @@ function generateForGrade(year: number, n = 100): MathQuestion[] {
   return Array.from({ length: n }, () => generateQuestion(undefined, year));
 }
 
+/** Gera N questões de uma operação para um ano escolar. */
+function generateManyForGrade(
+  op: Operation,
+  year: number,
+  n = 200,
+): MathQuestion[] {
+  return Array.from({ length: n }, () => generateQuestion(op, year));
+}
+
 /** Extrai o símbolo da operação do texto da questão. */
 function getSymbol(text: string): string {
   if (text.includes("+")) return "+";
@@ -27,7 +36,22 @@ function getSymbol(text: string): string {
   return "?";
 }
 
-/* ── Testes gerais (sem ano — padrão 3º) ─────────────────────── */
+/** Extrai os dois operandos do texto. */
+function parseOperands(text: string): [number, number] {
+  const clean = text.replace("= ?", "").trim();
+  // Identifica o operador para split correto
+  for (const sep of ["+", "×", "÷", "-"]) {
+    if (clean.includes(sep)) {
+      const [a, b] = clean.split(sep).map(Number);
+      return [a, b];
+    }
+  }
+  throw new Error(`Operador não encontrado em: ${text}`);
+}
+
+/* ══════════════════════════════════════════════════════════════
+ * Testes gerais (sem ano — padrão 3º)
+ * ══════════════════════════════════════════════════════════════ */
 
 describe("generateQuestion", () => {
   it("retorna todas as propriedades obrigatórias", () => {
@@ -166,9 +190,9 @@ describe("divisão", () => {
   });
 });
 
-/* ═══════════════════════════════════════════════════════
+/* ══════════════════════════════════════════════════════════════
  * Testes por ano escolar (#44)
- * ═══════════════════════════════════════════════════════ */
+ * ══════════════════════════════════════════════════════════════ */
 
 describe("getOperationsForGrade", () => {
   it("1º ano: apenas adição e subtração", () => {
@@ -195,7 +219,11 @@ describe("getOperationsForGrade", () => {
   });
 });
 
-describe("1º ano", () => {
+/* ══════════════════════════════════════════════════════════════
+ * BNCC — 1º ao 3º ano (Fundamental 1 inicial) — Issue #45
+ * ══════════════════════════════════════════════════════════════ */
+
+describe("1º ano — BNCC", () => {
   it("gera apenas adição e subtração", () => {
     const questions = generateForGrade(1, 200);
     for (const q of questions) {
@@ -204,12 +232,10 @@ describe("1º ano", () => {
     }
   });
 
-  it("adição: operandos entre 1 e 9", () => {
-    const questions = Array.from({ length: 200 }, () =>
-      generateQuestion("addition", 1),
-    );
+  it("adição: operandos são dígitos únicos (1–9)", () => {
+    const questions = generateManyForGrade("addition", 1, 500);
     for (const q of questions) {
-      const [a, b] = q.text.replace("= ?", "").split("+").map(Number);
+      const [a, b] = parseOperands(q.text);
       expect(a).toBeGreaterThanOrEqual(1);
       expect(a).toBeLessThanOrEqual(9);
       expect(b).toBeGreaterThanOrEqual(1);
@@ -217,12 +243,42 @@ describe("1º ano", () => {
     }
   });
 
+  it("adição: resultado ≤ 10", () => {
+    const questions = generateManyForGrade("addition", 1, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("subtração: operandos são dígitos únicos (≤ 9)", () => {
+    const questions = generateManyForGrade("subtraction", 1, 500);
+    for (const q of questions) {
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(9);
+      expect(b).toBeLessThanOrEqual(9);
+    }
+  });
+
   it("subtração: resultado ≥ 0", () => {
-    const questions = Array.from({ length: 200 }, () =>
-      generateQuestion("subtraction", 1),
-    );
+    const questions = generateManyForGrade("subtraction", 1, 500);
     for (const q of questions) {
       expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("resposta errada ≥ 0", () => {
+    const questions = generateForGrade(1, 500);
+    for (const q of questions) {
+      expect(q.wrongAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("distraidores plausíveis (offset ≤ 3)", () => {
+    const questions = generateForGrade(1, 500);
+    for (const q of questions) {
+      const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
+      expect(diff).toBeGreaterThanOrEqual(1);
+      expect(diff).toBeLessThanOrEqual(3);
     }
   });
 
@@ -237,6 +293,198 @@ describe("1º ano", () => {
     }
   });
 });
+
+describe("2º ano — BNCC", () => {
+  it("gera adição, subtração e multiplicação", () => {
+    const questions = generateForGrade(2, 300);
+    const symbols = new Set(questions.map((q) => getSymbol(q.text)));
+    expect(symbols).toContain("+");
+    expect(symbols).toContain("-");
+    expect(symbols).toContain("×");
+    expect(symbols).not.toContain("÷"); // sem divisão no 2º ano
+  });
+
+  it("adição: resultado ≤ 50", () => {
+    const questions = generateManyForGrade("addition", 2, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("adição: operandos são números de até 2 dígitos", () => {
+    const questions = generateManyForGrade("addition", 2, 500);
+    for (const q of questions) {
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(99);
+      expect(b).toBeLessThanOrEqual(99);
+    }
+  });
+
+  it("subtração: resultado ≤ 50 e ≥ 0", () => {
+    const questions = generateManyForGrade("subtraction", 2, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+      expect(q.correctAnswer).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("multiplicação: apenas tabuada do 2 e do 5", () => {
+    const questions = generateManyForGrade("multiplication", 2, 500);
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect([2, 5]).toContain(a);
+    }
+  });
+
+  it("multiplicação: segundo operando entre 1 e 10", () => {
+    const questions = generateManyForGrade("multiplication", 2, 500);
+    for (const q of questions) {
+      const [, b] = parseOperands(q.text);
+      expect(b).toBeGreaterThanOrEqual(1);
+      expect(b).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("multiplicação: resultado ≤ 50 (5×10=50 é o máximo)", () => {
+    const questions = generateManyForGrade("multiplication", 2, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("todos os resultados usam números de até 2 dígitos", () => {
+    const questions = generateForGrade(2, 500);
+    for (const q of questions) {
+      // Resultado e operandos ≤ 99 (exceto resultado de soma que vai até 50)
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(99);
+      expect(b).toBeLessThanOrEqual(99);
+    }
+  });
+
+  it("distraidores plausíveis (offset ≤ 4)", () => {
+    const questions = generateForGrade(2, 500);
+    for (const q of questions) {
+      const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
+      expect(diff).toBeGreaterThanOrEqual(1);
+      expect(diff).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("resposta errada ≥ 0", () => {
+    const questions = generateForGrade(2, 500);
+    for (const q of questions) {
+      expect(q.wrongAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("3º ano — BNCC", () => {
+  it("gera as 4 operações", () => {
+    const questions = generateForGrade(3, 300);
+    const symbols = new Set(questions.map((q) => getSymbol(q.text)));
+    expect(symbols).toContain("+");
+    expect(symbols).toContain("-");
+    expect(symbols).toContain("×");
+    expect(symbols).toContain("÷");
+  });
+
+  it("adição: resultado ≤ 100", () => {
+    const questions = generateManyForGrade("addition", 3, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("subtração: resultado ≥ 0 e minuendo ≤ 100", () => {
+    const questions = generateManyForGrade("subtraction", 3, 500);
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(100);
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("multiplicação: tabuada completa até 5 (2, 3, 4, 5)", () => {
+    const questions = generateManyForGrade("multiplication", 3, 500);
+    const tablesUsed = new Set<number>();
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect([2, 3, 4, 5]).toContain(a);
+      tablesUsed.add(a);
+    }
+    // Verifica que todas as tabuadas (2–5) aparecem
+    expect(tablesUsed).toContain(2);
+    expect(tablesUsed).toContain(3);
+    expect(tablesUsed).toContain(4);
+    expect(tablesUsed).toContain(5);
+  });
+
+  it("multiplicação: segundo operando entre 1 e 10", () => {
+    const questions = generateManyForGrade("multiplication", 3, 500);
+    for (const q of questions) {
+      const [, b] = parseOperands(q.text);
+      expect(b).toBeGreaterThanOrEqual(1);
+      expect(b).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("multiplicação: resultado ≤ 100 (5×10=50 é o máximo real)", () => {
+    const questions = generateManyForGrade("multiplication", 3, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("divisão: divisor entre 2 e 5", () => {
+    const questions = generateManyForGrade("division", 3, 500);
+    for (const q of questions) {
+      const [, divisor] = parseOperands(q.text);
+      expect(divisor).toBeGreaterThanOrEqual(2);
+      expect(divisor).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("divisão: resultado sempre inteiro", () => {
+    const questions = generateManyForGrade("division", 3, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("divisão: dividendo ≤ 100", () => {
+    const questions = generateManyForGrade("division", 3, 500);
+    for (const q of questions) {
+      const [dividend] = parseOperands(q.text);
+      expect(dividend).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("nenhuma questão gera resultado negativo", () => {
+    const questions = generateForGrade(3, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("distraidores plausíveis (offset ≤ 5)", () => {
+    const questions = generateForGrade(3, 500);
+    for (const q of questions) {
+      const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
+      expect(diff).toBeGreaterThanOrEqual(1);
+      expect(diff).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("resposta errada ≥ 0", () => {
+    const questions = generateForGrade(3, 500);
+    for (const q of questions) {
+      expect(q.wrongAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+/* ── Testes anos 5 e 9 (regressão #44) ──────────────────────── */
 
 describe("5º ano", () => {
   it("gera as 4 operações", () => {
@@ -284,6 +532,8 @@ describe("9º ano", () => {
     }
   });
 });
+
+/* ── Validação de entrada ────────────────────────────────────── */
 
 describe("validação de entrada", () => {
   it("ano < 1 é tratado como 1", () => {

--- a/src/lib/generateQuestion.ts
+++ b/src/lib/generateQuestion.ts
@@ -2,13 +2,19 @@
  * Gerador de questões de matemática por ano escolar.
  *
  * Cada ano (1º ao 9º) possui faixas de números e operações
- * adequadas ao nível do aluno. O padrão é 3º ano.
+ * adequadas ao nível do aluno, seguindo as diretrizes da BNCC.
+ * O padrão é 3º ano.
  *
  * Regras gerais:
  * - Divisões sempre com resultado inteiro
  * - Resposta incorreta plausível (próxima da correta)
  * - Posição da resposta correta (esquerda/direita) aleatória
  * - As duas opções são sempre diferentes
+ *
+ * BNCC — Fundamental 1 (anos iniciais):
+ * - 1º ano: soma/subtração com dígitos únicos, resultados ≤ 10
+ * - 2º ano: +/- com resultados ≤ 50, tabuada do 2 e do 5
+ * - 3º ano: 4 operações, números até 100, tabuada completa até 5
  */
 
 export type Operation = "addition" | "subtraction" | "multiplication" | "division";
@@ -56,7 +62,7 @@ function generateWrongAnswer(correct: number, maxOffset: number = 5): number {
 }
 
 /* ═══════════════════════════════════════════════════════
- * Configuração por ano escolar (#44)
+ * Configuração por ano escolar (#44 + #45 BNCC)
  * ═══════════════════════════════════════════════════════ */
 
 /**
@@ -64,48 +70,62 @@ function generateWrongAnswer(correct: number, maxOffset: number = 5): number {
  *
  * - `operations`: quais operações são habilitadas no ano
  * - `add`: [aMin, aMax, bMin, bMax]
+ * - `addMaxResult`: (opcional) limite máximo para a soma a+b
  * - `sub`: [aMin, aMax, bMin] — bMax é limitado a `a` (resultado ≥ 0)
  * - `mul`: [aMin, aMax, bMin, bMax]
+ * - `mulTables`: (opcional) restringe o 1º operando a tabuadas específicas
  * - `div`: [answerMin, answerMax, divisorMin, divisorMax]
  * - `wrongOffset`: offset máximo para a resposta errada
  */
 interface GradeConfig {
   operations: Operation[];
   add: [number, number, number, number];
+  addMaxResult?: number;
   sub: [number, number, number];
   mul: [number, number, number, number];
+  mulTables?: number[];
   div: [number, number, number, number];
   wrongOffset: number;
 }
 
 const GRADE_CONFIGS: Record<number, GradeConfig> = {
-  /* 1º ano — soma e subtração com números até 10 */
+  /* ── BNCC Fundamental 1 — anos iniciais ────────────────────── */
+
+  /* 1º ano — BNCC: dígitos únicos, soma ≤ 10, subtração ≤ 10 */
   1: {
     operations: ["addition", "subtraction"],
     add: [1, 9, 1, 9],
-    sub: [2, 10, 1],
+    addMaxResult: 10,
+    sub: [2, 9, 1],
     mul: [2, 3, 1, 3],
     div: [1, 5, 2, 3],
     wrongOffset: 3,
   },
-  /* 2º ano — soma/subtração maiores, início da multiplicação */
+  /* 2º ano — BNCC: +/− resultados ≤ 50, tabuada do 2 e do 5 */
   2: {
     operations: ["addition", "subtraction", "multiplication"],
-    add: [5, 50, 5, 50],
+    add: [2, 48, 2, 48],
+    addMaxResult: 50,
     sub: [10, 50, 1],
-    mul: [2, 5, 2, 5],
+    mul: [2, 5, 1, 10],
+    mulTables: [2, 5],
     div: [2, 5, 2, 5],
     wrongOffset: 4,
   },
-  /* 3º ano — 4 operações básicas (nível padrão atual) */
+  /* 3º ano — BNCC: 4 operações, números até 100, tabuada até 5 */
   3: {
     operations: ["addition", "subtraction", "multiplication", "division"],
-    add: [10, 99, 10, 99],
-    sub: [20, 99, 10],
-    mul: [2, 10, 2, 10],
-    div: [2, 10, 2, 10],
+    add: [5, 95, 5, 95],
+    addMaxResult: 100,
+    sub: [10, 100, 1],
+    mul: [2, 5, 1, 10],
+    mulTables: [2, 3, 4, 5],
+    div: [2, 10, 2, 5],
     wrongOffset: 5,
   },
+
+  /* ── Fundamental 1 — anos finais ───────────────────────────── */
+
   /* 4º ano — números um pouco maiores, tabuada completa */
   4: {
     operations: ["addition", "subtraction", "multiplication", "division"],
@@ -124,6 +144,9 @@ const GRADE_CONFIGS: Record<number, GradeConfig> = {
     div: [3, 15, 3, 12],
     wrongOffset: 8,
   },
+
+  /* ── Fundamental 2 ─────────────────────────────────────────── */
+
   /* 6º ano — números maiores */
   6: {
     operations: ["addition", "subtraction", "multiplication", "division"],
@@ -166,6 +189,16 @@ const GRADE_CONFIGS: Record<number, GradeConfig> = {
 
 function generateAddition(cfg: GradeConfig): { text: string; answer: number } {
   const [aMin, aMax, bMin, bMax] = cfg.add;
+
+  if (cfg.addMaxResult !== undefined) {
+    // Limita operandos para garantir soma ≤ addMaxResult
+    const effectiveAMax = Math.min(aMax, cfg.addMaxResult - bMin);
+    const a = randInt(aMin, effectiveAMax);
+    const effectiveBMax = Math.min(bMax, cfg.addMaxResult - a);
+    const b = randInt(bMin, effectiveBMax);
+    return { text: `${a} + ${b} = ?`, answer: a + b };
+  }
+
   const a = randInt(aMin, aMax);
   const b = randInt(bMin, bMax);
   return { text: `${a} + ${b} = ?`, answer: a + b };
@@ -181,7 +214,8 @@ function generateSubtraction(cfg: GradeConfig): { text: string; answer: number }
 
 function generateMultiplication(cfg: GradeConfig): { text: string; answer: number } {
   const [aMin, aMax, bMin, bMax] = cfg.mul;
-  const a = randInt(aMin, aMax);
+  // Se mulTables definido, usa apenas as tabuadas especificadas (BNCC)
+  const a = cfg.mulTables ? pick(cfg.mulTables) : randInt(aMin, aMax);
   const b = randInt(bMin, bMax);
   return { text: `${a} × ${b} = ?`, answer: a * b };
 }


### PR DESCRIPTION
## Issue #45 — Conteúdos do 1º ao 3º ano

### O que mudou

Ajusta o gerador de questões (`generateQuestion.ts`) para seguir as diretrizes da **BNCC** para os anos iniciais do Fundamental 1.

#### 1º ano
- ✅ Soma com resultados **≤ 10** (`addMaxResult`)
- ✅ Subtração com operandos de **dígito único** (≤ 9)
- ✅ Apenas adição e subtração

#### 2º ano
- ✅ Soma com resultados **≤ 50**
- ✅ Tabuada **apenas do 2 e do 5** (`mulTables: [2, 5]`)
- ✅ Números de até 2 dígitos

#### 3º ano
- ✅ 4 operações com números **até 100**
- ✅ Tabuada completa **até 5** (2, 3, 4, 5)
- ✅ Divisões exatas com **divisor 2–5**
- ✅ Soma com resultados **≤ 100**

### Critérios de aceite
- ✅ Cada ano gera questões dentro do escopo definido
- ✅ Distraidores plausíveis (offset proporcional: 3/4/5)
- ✅ Nenhuma questão gera resultado negativo
- ✅ Divisões são sempre exatas
- ✅ **57 testes** cobrindo todas as regras BNCC

### Arquitetura
- Dois novos campos opcionais em `GradeConfig`:
  - `addMaxResult` — limita a soma máxima (garante a+b ≤ N)
  - `mulTables` — restringe 1º operando a tabuadas específicas
- Geradores atualizados para respeitar as novas restrições
- Zero impacto nos anos 4–9 (sem breaking changes)

Closes #45