### PR TITLE
feat: conteúdos do 4º e 5º ano — frações, expressões e tabuada (#46)

### DIFF
--- a/src/lib/__tests__/generateQuestion.test.ts
+++ b/src/lib/__tests__/generateQuestion.test.ts
@@ -27,8 +27,18 @@ function generateManyForGrade(
   return Array.from({ length: n }, () => generateQuestion(op, year));
 }
 
-/** Extrai o símbolo da operação do texto da questão. */
+/**
+ * Extrai o tipo de questão do texto.
+ *
+ * - Frações: "½ de 20 = ?" → "frac"
+ * - Expressões (2 operadores): "3 × 4 + 2 = ?" → "expr"
+ * - Operação simples: "+", "-", "×", "÷"
+ */
 function getSymbol(text: string): string {
+  if (/^[½¼¾]/.test(text)) return "frac";
+  // Expressão: 3 ou mais números com 2+ operadores
+  const ops = text.replace(/= \?/, "").match(/[+\-×÷]/g);
+  if (ops && ops.length >= 2) return "expr";
   if (text.includes("+")) return "+";
   if (text.includes("×")) return "×";
   if (text.includes("÷")) return "÷";
@@ -36,7 +46,7 @@ function getSymbol(text: string): string {
   return "?";
 }
 
-/** Extrai os dois operandos do texto. */
+/** Extrai os dois operandos do texto de uma operação simples. */
 function parseOperands(text: string): [number, number] {
   const clean = text.replace("= ?", "").trim();
   // Identifica o operador para split correto
@@ -47,6 +57,34 @@ function parseOperands(text: string): [number, number] {
     }
   }
   throw new Error(`Operador não encontrado em: ${text}`);
+}
+
+/** Extrai dados de uma questão de fração: "½ de 20 = ?" */
+function parseFraction(text: string): { symbol: string; whole: number } {
+  const match = text.match(/^([½¼¾])\s+de\s+(\d+)/);
+  if (!match) throw new Error(`Não é uma fração: ${text}`);
+  return { symbol: match[1], whole: Number(match[2]) };
+}
+
+/** Extrai dados de uma expressão: "3 × 4 + 2 = ?" */
+function parseExpression(text: string): {
+  a: number;
+  op1: string;
+  b: number;
+  op2: string;
+  c: number;
+} {
+  const match = text.match(
+    /^(\d+)\s*([×÷])\s*(\d+)\s*([+\-])\s*(\d+)/,
+  );
+  if (!match) throw new Error(`Não é uma expressão: ${text}`);
+  return {
+    a: Number(match[1]),
+    op1: match[2],
+    b: Number(match[3]),
+    op2: match[4],
+    c: Number(match[5]),
+  };
 }
 
 /* ══════════════════════════════════════════════════════════════
@@ -207,8 +245,30 @@ describe("getOperationsForGrade", () => {
     ]);
   });
 
-  it("3º ao 9º ano: todas as 4 operações", () => {
-    for (let y = 3; y <= 9; y++) {
+  it("3º e 4º ano: 4 operações básicas", () => {
+    for (const y of [3, 4]) {
+      expect(getOperationsForGrade(y)).toEqual([
+        "addition",
+        "subtraction",
+        "multiplication",
+        "division",
+      ]);
+    }
+  });
+
+  it("5º ano: 4 operações + fração + expressão", () => {
+    expect(getOperationsForGrade(5)).toEqual([
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "fraction",
+      "expression",
+    ]);
+  });
+
+  it("6º ao 9º ano: 4 operações básicas", () => {
+    for (let y = 6; y <= 9; y++) {
       expect(getOperationsForGrade(y)).toEqual([
         "addition",
         "subtraction",
@@ -484,31 +544,404 @@ describe("3º ano — BNCC", () => {
   });
 });
 
-/* ── Testes anos 5 e 9 (regressão #44) ──────────────────────── */
+/* ══════════════════════════════════════════════════════════════
+ * BNCC — 4º ano (Fundamental 1 avançado) — Issue #46
+ * ══════════════════════════════════════════════════════════════ */
 
-describe("5º ano", () => {
-  it("gera as 4 operações", () => {
-    const questions = generateForGrade(5, 200);
+describe("4º ano — BNCC", () => {
+  it("gera as 4 operações básicas", () => {
+    const questions = generateForGrade(4, 300);
     const symbols = new Set(questions.map((q) => getSymbol(q.text)));
     expect(symbols).toContain("+");
     expect(symbols).toContain("-");
     expect(symbols).toContain("×");
     expect(symbols).toContain("÷");
+    // Não deve gerar frações nem expressões
+    expect(symbols).not.toContain("frac");
+    expect(symbols).not.toContain("expr");
   });
 
-  it("adição: operandos entre 100 e 500", () => {
-    const questions = Array.from({ length: 200 }, () =>
-      generateQuestion("addition", 5),
-    );
+  /* ── Adição e subtração até 1000 ── */
+
+  it("adição: resultado ≤ 1000", () => {
+    const questions = generateManyForGrade("addition", 4, 500);
     for (const q of questions) {
-      const [a, b] = q.text.replace("= ?", "").split("+").map(Number);
-      expect(a).toBeGreaterThanOrEqual(100);
+      expect(q.correctAnswer).toBeLessThanOrEqual(1000);
+    }
+  });
+
+  it("adição: operandos entre 10 e 500", () => {
+    const questions = generateManyForGrade("addition", 4, 500);
+    for (const q of questions) {
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeGreaterThanOrEqual(10);
       expect(a).toBeLessThanOrEqual(500);
-      expect(b).toBeGreaterThanOrEqual(100);
+      expect(b).toBeGreaterThanOrEqual(10);
       expect(b).toBeLessThanOrEqual(500);
     }
   });
+
+  it("subtração: resultado ≥ 0 e minuendo ≤ 1000", () => {
+    const questions = generateManyForGrade("subtraction", 4, 500);
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(1000);
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  /* ── Tabuada completa até 10 ── */
+
+  it("multiplicação: tabuada completa até 10 (tabelas 2 a 10)", () => {
+    const questions = generateManyForGrade("multiplication", 4, 1000);
+    const tablesUsed = new Set<number>();
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect(a).toBeGreaterThanOrEqual(2);
+      expect(a).toBeLessThanOrEqual(10);
+      tablesUsed.add(a);
+    }
+    // Todas as tabuadas de 2 a 10 devem aparecer
+    for (let t = 2; t <= 10; t++) {
+      expect(tablesUsed).toContain(t);
+    }
+  });
+
+  it("multiplicação: segundo operando entre 1 e 10", () => {
+    const questions = generateManyForGrade("multiplication", 4, 500);
+    for (const q of questions) {
+      const [, b] = parseOperands(q.text);
+      expect(b).toBeGreaterThanOrEqual(1);
+      expect(b).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("multiplicação: resultado ≤ 100 (10×10 é o máximo)", () => {
+    const questions = generateManyForGrade("multiplication", 4, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(100);
+    }
+  });
+
+  /* ── Divisão com números maiores ── */
+
+  it("divisão: resultado sempre inteiro", () => {
+    const questions = generateManyForGrade("division", 4, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("divisão: divisor entre 2 e 10", () => {
+    const questions = generateManyForGrade("division", 4, 500);
+    for (const q of questions) {
+      const [, divisor] = parseOperands(q.text);
+      expect(divisor).toBeGreaterThanOrEqual(2);
+      expect(divisor).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("divisão: dividendo ≤ 100 (10×10)", () => {
+    const questions = generateManyForGrade("division", 4, 500);
+    for (const q of questions) {
+      const [dividend] = parseOperands(q.text);
+      expect(dividend).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("divisão: pode gerar dividendos maiores (ex: 72 ÷ 9)", () => {
+    // Verifica que dividendos ≥ 20 aparecem (não ficam limitados como 3º ano)
+    const questions = generateManyForGrade("division", 4, 500);
+    const maxDividend = Math.max(
+      ...questions.map((q) => parseOperands(q.text)[0]),
+    );
+    expect(maxDividend).toBeGreaterThanOrEqual(20);
+  });
+
+  /* ── Regras gerais ── */
+
+  it("nenhuma questão gera resultado negativo", () => {
+    const questions = generateForGrade(4, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("resposta errada ≥ 0", () => {
+    const questions = generateForGrade(4, 500);
+    for (const q of questions) {
+      expect(q.wrongAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("distraidores plausíveis (offset ≤ 5)", () => {
+    const questions = generateForGrade(4, 500);
+    for (const q of questions) {
+      const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
+      expect(diff).toBeGreaterThanOrEqual(1);
+      expect(diff).toBeLessThanOrEqual(5);
+    }
+  });
 });
+
+/* ══════════════════════════════════════════════════════════════
+ * BNCC — 5º ano (Fundamental 1 avançado) — Issue #46
+ * ══════════════════════════════════════════════════════════════ */
+
+describe("5º ano — BNCC", () => {
+  it("gera 6 tipos de questão (4 operações + fração + expressão)", () => {
+    const questions = generateForGrade(5, 500);
+    const types = new Set(questions.map((q) => getSymbol(q.text)));
+    expect(types).toContain("+");
+    expect(types).toContain("-");
+    expect(types).toContain("×");
+    expect(types).toContain("÷");
+    expect(types).toContain("frac");
+    expect(types).toContain("expr");
+  });
+
+  /* ── Operações com números até 10.000 ── */
+
+  it("adição: resultado ≤ 10.000", () => {
+    const questions = generateManyForGrade("addition", 5, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeLessThanOrEqual(10000);
+    }
+  });
+
+  it("adição: operandos entre 100 e 5000", () => {
+    const questions = generateManyForGrade("addition", 5, 500);
+    for (const q of questions) {
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeGreaterThanOrEqual(100);
+      expect(a).toBeLessThanOrEqual(5000);
+      expect(b).toBeGreaterThanOrEqual(100);
+      expect(b).toBeLessThanOrEqual(5000);
+    }
+  });
+
+  it("subtração: resultado ≥ 0 e minuendo ≤ 10.000", () => {
+    const questions = generateManyForGrade("subtraction", 5, 500);
+    for (const q of questions) {
+      const [a] = parseOperands(q.text);
+      expect(a).toBeLessThanOrEqual(10000);
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  /* ── Multiplicação e divisão maiores ── */
+
+  it("multiplicação: resultados maiores que 4º ano", () => {
+    const questions = generateManyForGrade("multiplication", 5, 500);
+    const maxResult = Math.max(...questions.map((q) => q.correctAnswer));
+    expect(maxResult).toBeGreaterThan(100);
+  });
+
+  it("multiplicação: operandos entre 5 e 20", () => {
+    const questions = generateManyForGrade("multiplication", 5, 500);
+    for (const q of questions) {
+      const [a, b] = parseOperands(q.text);
+      expect(a).toBeGreaterThanOrEqual(5);
+      expect(a).toBeLessThanOrEqual(20);
+      expect(b).toBeGreaterThanOrEqual(5);
+      expect(b).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("divisão: resultado sempre inteiro", () => {
+    const questions = generateManyForGrade("division", 5, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("divisão: resultado entre 5 e 20, divisor entre 5 e 15", () => {
+    const questions = generateManyForGrade("division", 5, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(5);
+      expect(q.correctAnswer).toBeLessThanOrEqual(20);
+      const [, divisor] = parseOperands(q.text);
+      expect(divisor).toBeGreaterThanOrEqual(5);
+      expect(divisor).toBeLessThanOrEqual(15);
+    }
+  });
+
+  /* ── Frações simples: ½, ¼, ¾ ── */
+
+  it("fração: texto no formato correto (ex: ½ de 20 = ?)", () => {
+    const questions = generateManyForGrade("fraction", 5, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^[½¼¾] de \d+ = \?$/);
+    }
+  });
+
+  it("fração: usa os 3 símbolos (½, ¼, ¾)", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    const symbols = new Set(questions.map((q) => parseFraction(q.text).symbol));
+    expect(symbols).toContain("½");
+    expect(symbols).toContain("¼");
+    expect(symbols).toContain("¾");
+  });
+
+  it("fração: resultado sempre inteiro", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("fração: resultado ≥ 1", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("fração: resposta correta confere com a fração", () => {
+    const fractionValues: Record<string, [number, number]> = {
+      "½": [1, 2],
+      "¼": [1, 4],
+      "¾": [3, 4],
+    };
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      const { symbol, whole } = parseFraction(q.text);
+      const [num, den] = fractionValues[symbol];
+      expect(q.correctAnswer).toBe((whole * num) / den);
+    }
+  });
+
+  it("fração ½: número inteiro é sempre par", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      const { symbol, whole } = parseFraction(q.text);
+      if (symbol === "½") {
+        expect(whole % 2).toBe(0);
+      }
+    }
+  });
+
+  it("fração ¼ e ¾: número inteiro é sempre múltiplo de 4", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      const { symbol, whole } = parseFraction(q.text);
+      if (symbol === "¼" || symbol === "¾") {
+        expect(whole % 4).toBe(0);
+      }
+    }
+  });
+
+  it("fração: número inteiro entre 4 e 100", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      const { whole } = parseFraction(q.text);
+      expect(whole).toBeGreaterThanOrEqual(4);
+      expect(whole).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("fração: distrator plausível e proporcional à resposta", () => {
+    const questions = generateManyForGrade("fraction", 5, 500);
+    for (const q of questions) {
+      const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
+      expect(diff).toBeGreaterThanOrEqual(1);
+      // Offset adaptativo: max(2, ceil(answer/3)), limitado ao wrongOffset do ano (10)
+      const maxExpected = Math.max(2, Math.min(10, Math.ceil(q.correctAnswer / 3)));
+      expect(diff).toBeLessThanOrEqual(maxExpected);
+    }
+  });
+
+  /* ── Expressões simples ── */
+
+  it("expressão: texto no formato correto (ex: 3 × 4 + 2 = ?)", () => {
+    const questions = generateManyForGrade("expression", 5, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^\d+ × \d+ [+\-] \d+ = \?$/);
+    }
+  });
+
+  it("expressão: resultado sempre ≥ 0", () => {
+    const questions = generateManyForGrade("expression", 5, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("expressão: resultado é sempre inteiro", () => {
+    const questions = generateManyForGrade("expression", 5, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("expressão: resposta confere (multiplicação primeiro)", () => {
+    const questions = generateManyForGrade("expression", 5, 500);
+    for (const q of questions) {
+      const { a, b, op2, c } = parseExpression(q.text);
+      const product = a * b;
+      const expected = op2 === "+" ? product + c : product - c;
+      expect(q.correctAnswer).toBe(expected);
+    }
+  });
+
+  it("expressão: operandos entre 2 e 10", () => {
+    const questions = generateManyForGrade("expression", 5, 500);
+    for (const q of questions) {
+      const { a, b, c } = parseExpression(q.text);
+      expect(a).toBeGreaterThanOrEqual(2);
+      expect(a).toBeLessThanOrEqual(10);
+      expect(b).toBeGreaterThanOrEqual(2);
+      expect(b).toBeLessThanOrEqual(10);
+      expect(c).toBeGreaterThanOrEqual(2);
+      expect(c).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("expressão: gera tanto + quanto - como segunda operação", () => {
+    const questions = generateManyForGrade("expression", 5, 500);
+    const secondOps = new Set(
+      questions.map((q) => parseExpression(q.text).op2),
+    );
+    expect(secondOps).toContain("+");
+    expect(secondOps).toContain("-");
+  });
+
+  /* ── Regras gerais 5º ano ── */
+
+  it("nenhuma questão gera resultado negativo", () => {
+    const questions = generateForGrade(5, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("resposta errada ≥ 0", () => {
+    const questions = generateForGrade(5, 500);
+    for (const q of questions) {
+      expect(q.wrongAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("left e right são sempre diferentes", () => {
+    const questions = generateForGrade(5, 500);
+    for (const q of questions) {
+      expect(q.leftValue).not.toBe(q.rightValue);
+    }
+  });
+
+  it("operação indisponível no 5º ano (fração no 4º) cai em válida", () => {
+    const questions = Array.from({ length: 50 }, () =>
+      generateQuestion("fraction", 4),
+    );
+    for (const q of questions) {
+      // 4º ano não tem fração → deve sortear outra operação
+      const sym = getSymbol(q.text);
+      expect(["+", "-", "×", "÷"]).toContain(sym);
+    }
+  });
+});
+
+/* ── Testes anos 9 (regressão #44) ──────────────────────────── */
 
 describe("9º ano", () => {
   it("adição: operandos maiores", () => {

--- a/src/lib/__tests__/speech.test.ts
+++ b/src/lib/__tests__/speech.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { buildNarration } from "../speech";
+
+/**
+ * Testes do buildNarration (#46).
+ *
+ * Verifica que a narração por voz funciona para:
+ * 1. Operações simples (adição, subtração, multiplicação, divisão)
+ * 2. Frações (½, ¼, ¾)
+ * 3. Expressões com duas operações
+ */
+describe("buildNarration", () => {
+  /* ── Operações simples ── */
+
+  it("adição: narra corretamente", () => {
+    expect(buildNarration("12 + 15 = ?", 27, 30)).toBe(
+      "Quanto é 12 mais 15? À esquerda, 27. À direita, 30.",
+    );
+  });
+
+  it("subtração: narra corretamente", () => {
+    expect(buildNarration("50 - 23 = ?", 30, 27)).toBe(
+      "Quanto é 50 menos 23? À esquerda, 30. À direita, 27.",
+    );
+  });
+
+  it("multiplicação: narra corretamente", () => {
+    expect(buildNarration("7 × 8 = ?", 56, 54)).toBe(
+      "Quanto é 7 vezes 8? À esquerda, 56. À direita, 54.",
+    );
+  });
+
+  it("divisão: narra corretamente", () => {
+    expect(buildNarration("72 ÷ 9 = ?", 8, 10)).toBe(
+      "Quanto é 72 dividido por 9? À esquerda, 8. À direita, 10.",
+    );
+  });
+
+  /* ── Frações (#46) ── */
+
+  it("fração ½: narra 'metade de'", () => {
+    expect(buildNarration("½ de 20 = ?", 10, 12)).toBe(
+      "Quanto é metade de 20? À esquerda, 10. À direita, 12.",
+    );
+  });
+
+  it("fração ¼: narra 'um quarto de'", () => {
+    expect(buildNarration("¼ de 12 = ?", 3, 5)).toBe(
+      "Quanto é um quarto de 12? À esquerda, 3. À direita, 5.",
+    );
+  });
+
+  it("fração ¾: narra 'três quartos de'", () => {
+    expect(buildNarration("¾ de 40 = ?", 30, 28)).toBe(
+      "Quanto é três quartos de 40? À esquerda, 30. À direita, 28.",
+    );
+  });
+
+  /* ── Expressões (#46) ── */
+
+  it("expressão com +: narra corretamente", () => {
+    expect(buildNarration("3 × 4 + 2 = ?", 14, 12)).toBe(
+      "Quanto é 3 vezes 4 mais 2? À esquerda, 14. À direita, 12.",
+    );
+  });
+
+  it("expressão com -: narra corretamente", () => {
+    expect(buildNarration("5 × 3 - 4 = ?", 11, 13)).toBe(
+      "Quanto é 5 vezes 3 menos 4? À esquerda, 11. À direita, 13.",
+    );
+  });
+
+  /* ── Texto inválido ── */
+
+  it("retorna string vazia para texto não reconhecido", () => {
+    expect(buildNarration("texto aleatório", 1, 2)).toBe("");
+  });
+});

--- a/src/lib/generateQuestion.ts
+++ b/src/lib/generateQuestion.ts
@@ -7,6 +7,8 @@
  *
  * Regras gerais:
  * - Divisões sempre com resultado inteiro
+ * - Frações sempre com resultado inteiro
+ * - Expressões nunca com resultado negativo
  * - Resposta incorreta plausível (próxima da correta)
  * - Posição da resposta correta (esquerda/direita) aleatória
  * - As duas opções são sempre diferentes
@@ -15,9 +17,19 @@
  * - 1º ano: soma/subtração com dígitos únicos, resultados ≤ 10
  * - 2º ano: +/- com resultados ≤ 50, tabuada do 2 e do 5
  * - 3º ano: 4 operações, números até 100, tabuada completa até 5
+ *
+ * BNCC — Fundamental 1 (anos avançados):
+ * - 4º ano: tabuada completa até 10, números até 1000
+ * - 5º ano: números até 10.000, frações (½, ¼, ¾), expressões simples
  */
 
-export type Operation = "addition" | "subtraction" | "multiplication" | "division";
+export type Operation =
+  | "addition"
+  | "subtraction"
+  | "multiplication"
+  | "division"
+  | "fraction"
+  | "expression";
 
 export interface MathQuestion {
   /** Texto da pergunta, ex: "12 + 15 = ?" */
@@ -62,7 +74,30 @@ function generateWrongAnswer(correct: number, maxOffset: number = 5): number {
 }
 
 /* ═══════════════════════════════════════════════════════
- * Configuração por ano escolar (#44 + #45 BNCC)
+ * Definição de frações (#46)
+ * ═══════════════════════════════════════════════════════ */
+
+/** Definição de uma fração simples para questões. */
+export interface FractionDef {
+  /** Símbolo Unicode da fração, ex: "½" */
+  symbol: string;
+  /** Numerador da fração */
+  numerator: number;
+  /** Denominador da fração */
+  denominator: number;
+  /** Texto para narração por voz, ex: "metade de" */
+  narration: string;
+}
+
+/** Frações simples usadas no 5º ano. */
+const FRACTIONS_5TH: FractionDef[] = [
+  { symbol: "½", numerator: 1, denominator: 2, narration: "metade de" },
+  { symbol: "¼", numerator: 1, denominator: 4, narration: "um quarto de" },
+  { symbol: "¾", numerator: 3, denominator: 4, narration: "três quartos de" },
+];
+
+/* ═══════════════════════════════════════════════════════
+ * Configuração por ano escolar (#44 + #45 + #46 BNCC)
  * ═══════════════════════════════════════════════════════ */
 
 /**
@@ -76,6 +111,9 @@ function generateWrongAnswer(correct: number, maxOffset: number = 5): number {
  * - `mulTables`: (opcional) restringe o 1º operando a tabuadas específicas
  * - `div`: [answerMin, answerMax, divisorMin, divisorMax]
  * - `wrongOffset`: offset máximo para a resposta errada
+ * - `fractions`: (opcional) definições de frações disponíveis
+ * - `fractionWholeRange`: (opcional) [min, max] do número inteiro para frações
+ * - `exprRange`: (opcional) [min, max] dos operandos para expressões
  */
 interface GradeConfig {
   operations: Operation[];
@@ -86,6 +124,9 @@ interface GradeConfig {
   mulTables?: number[];
   div: [number, number, number, number];
   wrongOffset: number;
+  fractions?: FractionDef[];
+  fractionWholeRange?: [number, number];
+  exprRange?: [number, number];
 }
 
 const GRADE_CONFIGS: Record<number, GradeConfig> = {
@@ -124,25 +165,51 @@ const GRADE_CONFIGS: Record<number, GradeConfig> = {
     wrongOffset: 5,
   },
 
-  /* ── Fundamental 1 — anos finais ───────────────────────────── */
+  /* ── BNCC Fundamental 1 — anos avançados (#46) ─────────────── */
 
-  /* 4º ano — números um pouco maiores, tabuada completa */
+  /**
+   * 4º ano — BNCC:
+   * - Tabuada completa até 10
+   * - Multiplicação com resultados até 100 (ex: 10 × 10 = 100)
+   * - Divisão com números maiores (ex: 72 ÷ 9 = 8)
+   * - Adição e subtração com números até 1000
+   */
   4: {
     operations: ["addition", "subtraction", "multiplication", "division"],
-    add: [50, 200, 50, 200],
-    sub: [50, 300, 10],
-    mul: [2, 12, 2, 12],
-    div: [2, 12, 2, 12],
+    add: [10, 500, 10, 500],
+    addMaxResult: 1000,
+    sub: [10, 1000, 1],
+    mul: [2, 10, 1, 10],
+    mulTables: [2, 3, 4, 5, 6, 7, 8, 9, 10],
+    div: [2, 10, 2, 10],
     wrongOffset: 5,
   },
-  /* 5º ano — centenas, multiplicação/divisão ampliadas */
+
+  /**
+   * 5º ano — BNCC:
+   * - Operações com números até 10.000
+   * - Frações simples: ½, ¼, ¾ (ex: ½ de 20 = ?)
+   * - Multiplicação e divisão com resultados maiores
+   * - Expressões simples com duas operações (ex: 3 × 4 + 2 = ?)
+   */
   5: {
-    operations: ["addition", "subtraction", "multiplication", "division"],
-    add: [100, 500, 100, 500],
-    sub: [100, 500, 50],
-    mul: [5, 15, 5, 15],
-    div: [3, 15, 3, 12],
-    wrongOffset: 8,
+    operations: [
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "fraction",
+      "expression",
+    ],
+    add: [100, 5000, 100, 5000],
+    addMaxResult: 10000,
+    sub: [100, 10000, 50],
+    mul: [5, 20, 5, 20],
+    div: [5, 20, 5, 15],
+    wrongOffset: 10,
+    fractions: FRACTIONS_5TH,
+    fractionWholeRange: [4, 100],
+    exprRange: [2, 10],
   },
 
   /* ── Fundamental 2 ─────────────────────────────────────────── */
@@ -185,9 +252,18 @@ const GRADE_CONFIGS: Record<number, GradeConfig> = {
   },
 };
 
+/* ── Resultado interno dos geradores ─────────────────────────── */
+
+interface GeneratorResult {
+  text: string;
+  answer: number;
+  /** Offset custom para a resposta errada (sobrescreve cfg.wrongOffset). */
+  wrongOffset?: number;
+}
+
 /* ── Geradores por operação (parametrizados) ─────────────────── */
 
-function generateAddition(cfg: GradeConfig): { text: string; answer: number } {
+function generateAddition(cfg: GradeConfig): GeneratorResult {
   const [aMin, aMax, bMin, bMax] = cfg.add;
 
   if (cfg.addMaxResult !== undefined) {
@@ -204,7 +280,7 @@ function generateAddition(cfg: GradeConfig): { text: string; answer: number } {
   return { text: `${a} + ${b} = ?`, answer: a + b };
 }
 
-function generateSubtraction(cfg: GradeConfig): { text: string; answer: number } {
+function generateSubtraction(cfg: GradeConfig): GeneratorResult {
   const [aMin, aMax, bMin] = cfg.sub;
   const a = randInt(aMin, aMax);
   // b ≤ a para garantir resultado ≥ 0
@@ -212,7 +288,7 @@ function generateSubtraction(cfg: GradeConfig): { text: string; answer: number }
   return { text: `${a} - ${b} = ?`, answer: a - b };
 }
 
-function generateMultiplication(cfg: GradeConfig): { text: string; answer: number } {
+function generateMultiplication(cfg: GradeConfig): GeneratorResult {
   const [aMin, aMax, bMin, bMax] = cfg.mul;
   // Se mulTables definido, usa apenas as tabuadas especificadas (BNCC)
   const a = cfg.mulTables ? pick(cfg.mulTables) : randInt(aMin, aMax);
@@ -220,7 +296,7 @@ function generateMultiplication(cfg: GradeConfig): { text: string; answer: numbe
   return { text: `${a} × ${b} = ?`, answer: a * b };
 }
 
-function generateDivision(cfg: GradeConfig): { text: string; answer: number } {
+function generateDivision(cfg: GradeConfig): GeneratorResult {
   const [ansMin, ansMax, divMin, divMax] = cfg.div;
   // Gera a partir do resultado para garantir divisão exata
   const answer = randInt(ansMin, ansMax);
@@ -229,13 +305,79 @@ function generateDivision(cfg: GradeConfig): { text: string; answer: number } {
   return { text: `${dividend} ÷ ${divisor} = ?`, answer };
 }
 
+/**
+ * Gera uma questão de fração simples.
+ *
+ * Exemplo: "½ de 20 = ?" → resposta 10.
+ * O número inteiro é sempre múltiplo do denominador,
+ * garantindo resultado inteiro.
+ *
+ * Usa um offset de distração proporcional à resposta para
+ * que o distrator seja plausível mesmo com respostas pequenas.
+ */
+function generateFraction(cfg: GradeConfig): GeneratorResult {
+  if (!cfg.fractions || cfg.fractions.length === 0) {
+    return generateAddition(cfg);
+  }
+
+  const frac = pick(cfg.fractions);
+  const [wholeMin, wholeMax] = cfg.fractionWholeRange ?? [4, 100];
+
+  // Gera um inteiro que é múltiplo do denominador → resultado sempre inteiro
+  const minMultiple = Math.ceil(wholeMin / frac.denominator);
+  const maxMultiple = Math.floor(wholeMax / frac.denominator);
+  const multiple = randInt(minMultiple, maxMultiple);
+  const whole = multiple * frac.denominator;
+
+  const answer = (whole * frac.numerator) / frac.denominator;
+
+  // Offset proporcional à resposta (mín 2, máx wrongOffset do ano)
+  const adaptiveOffset = Math.max(2, Math.min(cfg.wrongOffset, Math.ceil(answer / 3)));
+
+  return { text: `${frac.symbol} de ${whole} = ?`, answer, wrongOffset: adaptiveOffset };
+}
+
+/**
+ * Gera uma expressão simples com duas operações.
+ *
+ * Padrão: a × b + c ou a × b − c (multiplicação sempre primeiro).
+ * Segue a ordem natural de operações (PEMDAS) sem ambiguidade:
+ * a criança lê da esquerda para a direita e a resposta é correta.
+ *
+ * Resultado é sempre ≥ 0 (subtração só quando produto ≥ c).
+ */
+function generateExpression(cfg: GradeConfig): GeneratorResult {
+  const [min, max] = cfg.exprRange ?? [2, 10];
+
+  const a = randInt(min, max);
+  const b = randInt(min, max);
+  const c = randInt(min, max);
+
+  const product = a * b;
+
+  // Usa subtração somente se o resultado for ≥ 0
+  if (pick([true, false]) && product >= c) {
+    return {
+      text: `${a} × ${b} - ${c} = ?`,
+      answer: product - c,
+    };
+  }
+
+  return {
+    text: `${a} × ${b} + ${c} = ?`,
+    answer: product + c,
+  };
+}
+
 /* ── Função principal ────────────────────────────────────────── */
 
-const generators: Record<Operation, (cfg: GradeConfig) => { text: string; answer: number }> = {
+const generators: Record<Operation, (cfg: GradeConfig) => GeneratorResult> = {
   addition: generateAddition,
   subtraction: generateSubtraction,
   multiplication: generateMultiplication,
   division: generateDivision,
+  fraction: generateFraction,
+  expression: generateExpression,
 };
 
 /**
@@ -254,9 +396,10 @@ export function generateQuestion(operation?: Operation, schoolYear: number = 3):
       ? operation
       : pick<Operation>(cfg.operations);
 
-  const { text, answer } = generators[op](cfg);
+  const { text, answer, wrongOffset: customOffset } = generators[op](cfg);
+  const effectiveOffset = customOffset ?? cfg.wrongOffset;
 
-  const wrongAnswer = generateWrongAnswer(answer, cfg.wrongOffset);
+  const wrongAnswer = generateWrongAnswer(answer, effectiveOffset);
   const correctSide: "left" | "right" = pick(["left", "right"]);
 
   const leftValue = correctSide === "left" ? answer : wrongAnswer;

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -51,6 +51,13 @@ const OPERATOR_WORDS: Record<string, string> = {
   "÷": "dividido por",
 };
 
+/* ── Mapa de frações para narração em português (#46) ── */
+const FRACTION_NARRATIONS: Record<string, string> = {
+  "½": "metade",
+  "¼": "um quarto",
+  "¾": "três quartos",
+};
+
 /* ── Gestão de vozes ── */
 
 /**
@@ -240,19 +247,49 @@ export function speak(text: string): void {
 /**
  * Constrói a frase de narração para uma questão de matemática.
  *
- * Entrada: texto "12 + 15 = ?", leftValue 27, rightValue 30
- * Saída:   "Quanto é 12 mais 15? À esquerda, 27. À direita, 30."
+ * Suporta três formatos (#46):
+ *
+ * 1. Operação simples: "12 + 15 = ?"
+ *    → "Quanto é 12 mais 15? À esquerda, 27. À direita, 30."
+ *
+ * 2. Fração: "½ de 20 = ?"
+ *    → "Quanto é metade de 20? À esquerda, 10. À direita, 12."
+ *
+ * 3. Expressão: "3 × 4 + 2 = ?"
+ *    → "Quanto é 3 vezes 4 mais 2? À esquerda, 14. À direita, 12."
  */
 export function buildNarration(
   questionText: string,
   leftValue: number | string,
   rightValue: number | string,
 ): string {
+  const suffix = `À esquerda, ${leftValue}. À direita, ${rightValue}.`;
+
+  // 1. Fração: "½ de 20 = ?"
+  const fracMatch = questionText.match(/^([½¼¾])\s+de\s+(\d+)/);
+  if (fracMatch) {
+    const [, symbol, whole] = fracMatch;
+    const word = FRACTION_NARRATIONS[symbol] ?? symbol;
+    return `Quanto é ${word} de ${whole}? ${suffix}`;
+  }
+
+  // 2. Expressão: "3 × 4 + 2 = ?"
+  const exprMatch = questionText.match(
+    /^(\d+)\s*([+\-×÷])\s*(\d+)\s*([+\-×÷])\s*(\d+)/,
+  );
+  if (exprMatch) {
+    const [, a, op1, b, op2, c] = exprMatch;
+    const word1 = OPERATOR_WORDS[op1] ?? op1;
+    const word2 = OPERATOR_WORDS[op2] ?? op2;
+    return `Quanto é ${a} ${word1} ${b} ${word2} ${c}? ${suffix}`;
+  }
+
+  // 3. Operação simples: "12 + 15 = ?"
   const match = questionText.match(/^(\d+)\s*([+\-×÷])\s*(\d+)/);
   if (!match) return "";
 
   const [, a, op, b] = match;
   const word = OPERATOR_WORDS[op] ?? op;
 
-  return `Quanto é ${a} ${word} ${b}? À esquerda, ${leftValue}. À direita, ${rightValue}.`;
+  return `Quanto é ${a} ${word} ${b}? ${suffix}`;
 }


### PR DESCRIPTION
## Issue #46 — Conteúdos do 4º e 5º ano (Fundamental 1 — avançado)

### 4º ano (BNCC)
- ✅ Tabuada completa até 10 (tabelas 2 a 10)
- ✅ Multiplicação com resultados até 100 (ex: 10 × 10 = 100)
- ✅ Divisão com números maiores (ex: 72 ÷ 9 = 8)
- ✅ Adição e subtração com números até 1000

### 5º ano (BNCC)
- ✅ Operações com números até 10.000
- ✅ Frações simples: ½, ¼, ¾ (ex: ½ de 20 = 10)
- ✅ Expressões com duas operações (ex: 3 × 4 + 2 = 14)
- ✅ Multiplicação e divisão com resultados maiores
- ✅ Narração por voz: "metade de 20", "um quarto de 12", "três quartos de 40"

### Detalhes técnicos

**Novos tipos de operação:** `fraction` e `expression` adicionados ao tipo `Operation`.

**Gerador de frações (`generateFraction`):**
- Gera números inteiros múltiplos do denominador → resultado sempre inteiro
- Frações disponíveis: ½ (metade), ¼ (um quarto), ¾ (três quartos)
- Offset de distração adaptativo (proporcional à resposta)

**Gerador de expressões (`generateExpression`):**
- Padrão: `a × b + c` ou `a × b - c`
- Multiplicação sempre primeiro (sem ambiguidade PEMDAS)
- Subtração somente se resultado ≥ 0
- Operandos entre 2 e 10

**Narração por voz (`buildNarration`):**
- Frações: "Quanto é metade de 20?" / "Quanto é um quarto de 12?"
- Expressões: "Quanto é 3 vezes 4 mais 2?"

### Testes
- **108 testes** (98 generateQuestion + 10 speech) — todos passando
- Testes específicos para 4º ano: tabuada, divisão, limites
- Testes específicos para 5º ano: frações, expressões, todos os 6 tipos
- Teste de narração para todos os formatos

### Critérios de aceitação
- ✅ Questões dentro do escopo de cada ano
- ✅ Frações exibidas de forma legível (½, ¼, ¾ em fonte grande)
- ✅ Narração por voz funciona com frações e expressões
- ✅ Nenhum resultado negativo ou não inteiro

Closes #46
