### PR TITLE
feat: conteúdos do 6º e 7º ano (Fundamental 2 — inicial)

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -112,8 +112,8 @@ export default function GameScreen() {
 
     const text = buildNarration(
       question.text,
-      question.leftValue,
-      question.rightValue,
+      question.leftDisplay ?? question.leftValue,
+      question.rightDisplay ?? question.rightValue,
     );
     speak(text);
 
@@ -130,8 +130,8 @@ export default function GameScreen() {
     const interval = setInterval(() => {
       const text = buildNarration(
         question.text,
-        question.leftValue,
-        question.rightValue,
+        question.leftDisplay ?? question.leftValue,
+        question.rightDisplay ?? question.rightValue,
       );
       speak(text);
     }, voice.repeatDelay);
@@ -268,7 +268,7 @@ export default function GameScreen() {
         >
           <div className="flex-1 min-w-0">
             <AnswerOption
-              value={question.leftValue}
+              value={question.leftDisplay ?? question.leftValue}
               side="left"
               selected={selectedSide === "left" && phase === "playing"}
               selecting={selectedSide === "left" && phase === "selecting"}
@@ -279,7 +279,7 @@ export default function GameScreen() {
           </div>
           <div className="flex-1 min-w-0">
             <AnswerOption
-              value={question.rightValue}
+              value={question.rightDisplay ?? question.rightValue}
               side="right"
               selected={selectedSide === "right" && phase === "playing"}
               selecting={selectedSide === "right" && phase === "selecting"}

--- a/src/lib/__tests__/generateQuestion.test.ts
+++ b/src/lib/__tests__/generateQuestion.test.ts
@@ -30,11 +30,27 @@ function generateManyForGrade(
 /**
  * Extrai o tipo de questão do texto.
  *
- * - Frações: "½ de 20 = ?" → "frac"
+ * - Frações (5º): "½ de 20 = ?" → "frac"
  * - Expressões (2 operadores): "3 × 4 + 2 = ?" → "expr"
+ * - Potenciação: "2³ = ?" → "exp"
+ * - Decimal: "1,5 + 2,3 = ?" → "dec"
+ * - Fração mesmo denom: "²⁄₅ + ¹⁄₅ = ?" → "sameFrac"
+ * - Múltiplo/divisor: "Múltiplo de 6" → "md"
+ * - Negativo: "−3 + 5" → "neg"
+ * - Proporção: "Se 2 → 6" → "prop"
+ * - Parênteses: "(3 + 2) × 4" → "paren"
+ * - Porcentagem: "10% de 200" → "pct"
  * - Operação simples: "+", "-", "×", "÷"
  */
 function getSymbol(text: string): string {
+  if (/^\d+%/.test(text)) return "pct";
+  if (/^\d+[⁰¹²³⁴⁵⁶⁷⁸⁹]/.test(text)) return "exp";
+  if (/^\d+,\d+/.test(text)) return "dec";
+  if (/^[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄/.test(text)) return "sameFrac";
+  if (/^(Múltiplo|Divisor)/.test(text)) return "md";
+  if (/^Se \d+/.test(text)) return "prop";
+  if (/^\(/.test(text)) return "paren";
+  if (/^−\d+/.test(text)) return "neg";
   if (/^[½¼¾]/.test(text)) return "frac";
   // Expressão: 3 ou mais números com 2+ operadores
   const ops = text.replace(/= \?/, "").match(/[+\-×÷]/g);
@@ -84,6 +100,133 @@ function parseExpression(text: string): {
     b: Number(match[3]),
     op2: match[4],
     c: Number(match[5]),
+  };
+}
+
+/* ── Helpers Unicode (#47) ──────────────────────────────────── */
+
+const SUPERSCRIPTS = "⁰¹²³⁴⁵⁶⁷⁸⁹";
+const SUBSCRIPTS = "₀₁₂₃₄₅₆₇₈₉";
+
+function fromSuperscript(s: string): number {
+  return Number(
+    s
+      .split("")
+      .map((c) => String(SUPERSCRIPTS.indexOf(c)))
+      .join(""),
+  );
+}
+
+function fromSubscript(s: string): number {
+  return Number(
+    s
+      .split("")
+      .map((c) => String(SUBSCRIPTS.indexOf(c)))
+      .join(""),
+  );
+}
+
+/** Extrai base e expoente de "2³ = ?" */
+function parseExponentiation(text: string): { base: number; exp: number } {
+  const match = text.match(/^(\d+)([⁰¹²³⁴⁵⁶⁷⁸⁹]+)\s*=\s*\?/);
+  if (!match) throw new Error(`Não é potenciação: ${text}`);
+  return { base: Number(match[1]), exp: fromSuperscript(match[2]) };
+}
+
+/** Extrai operandos decimais: "1,5 + 2,3 = ?" → { a: 1.5, op: "+", b: 2.3 } */
+function parseDecimal(text: string): { a: number; op: string; b: number } {
+  const match = text.match(/^(\d+,\d+)\s*([+\-])\s*(\d+,\d+)/);
+  if (!match) throw new Error(`Não é decimal: ${text}`);
+  return {
+    a: Number(match[1].replace(",", ".")),
+    op: match[2],
+    b: Number(match[3].replace(",", ".")),
+  };
+}
+
+/** Extrai frações com mesmo denominador: "²⁄₅ + ¹⁄₅ = ?" */
+function parseSameDenomFraction(text: string): {
+  n1: number;
+  d1: number;
+  op: string;
+  n2: number;
+  d2: number;
+} {
+  const match = text.match(
+    /^([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)\s*([+−])\s*([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)/,
+  );
+  if (!match) throw new Error(`Não é fração mesmo denom: ${text}`);
+  return {
+    n1: fromSuperscript(match[1]),
+    d1: fromSubscript(match[2]),
+    op: match[3],
+    n2: fromSuperscript(match[4]),
+    d2: fromSubscript(match[5]),
+  };
+}
+
+/** Extrai múltiplo/divisor: "Múltiplo de 6 = ?" */
+function parseMultDiv(text: string): { type: string; base: number } {
+  const match = text.match(/^(Múltiplo|Divisor) de (\d+)/);
+  if (!match) throw new Error(`Não é múltiplo/divisor: ${text}`);
+  return { type: match[1], base: Number(match[2]) };
+}
+
+/** Extrai dados de operação com negativos: "−3 + 5 = ?" */
+function parseNegative(text: string): { a: number; op: string; b: number } {
+  const match = text.match(/^−(\d+)\s*([+−])\s*(\d+)/);
+  if (!match) throw new Error(`Não é operação com negativos: ${text}`);
+  return { a: Number(match[1]), op: match[2], b: Number(match[3]) };
+}
+
+/** Extrai proporção: "Se 2 → 6, 4 → ?" */
+function parseProportion(text: string): {
+  a: number;
+  b: number;
+  c: number;
+} {
+  const match = text.match(/^Se (\d+) → (\d+), (\d+) → \?/);
+  if (!match) throw new Error(`Não é proporção: ${text}`);
+  return { a: Number(match[1]), b: Number(match[2]), c: Number(match[3]) };
+}
+
+/** Extrai expressão com parênteses: "(3 + 2) × 4 = ?" */
+function parseParentheses(text: string): {
+  a: number;
+  op1: string;
+  b: number;
+  op2: string;
+  c: number;
+} {
+  const match = text.match(
+    /^\((\d+)\s*([+−])\s*(\d+)\)\s*([×÷])\s*(\d+)/,
+  );
+  if (!match) throw new Error(`Não é expressão com parênteses: ${text}`);
+  return {
+    a: Number(match[1]),
+    op1: match[2],
+    b: Number(match[3]),
+    op2: match[4],
+    c: Number(match[5]),
+  };
+}
+
+/** Extrai porcentagem: "10% de 200 = ?" */
+function parsePercentage(text: string): { pct: number; whole: number } {
+  const match = text.match(/^(\d+)% de (\d+)/);
+  if (!match) throw new Error(`Não é porcentagem: ${text}`);
+  return { pct: Number(match[1]), whole: Number(match[2]) };
+}
+
+/** Extrai display de fração Unicode: "³⁄₅" → { num: 3, den: 5 } */
+function parseDisplayFraction(display: string): { num: number; den: number } {
+  const match = display.match(
+    /^([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)$/,
+  );
+  if (!match) throw new Error(`Não é display de fração: ${display}`);
+  return {
+    num: fromSuperscript(match[1]),
+    den: fromSubscript(match[2]),
   };
 }
 
@@ -267,8 +410,34 @@ describe("getOperationsForGrade", () => {
     ]);
   });
 
-  it("6º ao 9º ano: 4 operações básicas", () => {
-    for (let y = 6; y <= 9; y++) {
+  it("6º ano: 4 operações + potenciação + decimal + fração mesmo denom + múltiplos/divisores", () => {
+    expect(getOperationsForGrade(6)).toEqual([
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "exponentiation",
+      "decimal",
+      "sameDenomFraction",
+      "multiplesDivisors",
+    ]);
+  });
+
+  it("7º ano: 4 operações + negativos + proporção + parênteses + porcentagem", () => {
+    expect(getOperationsForGrade(7)).toEqual([
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "negativeOps",
+      "proportion",
+      "parenthesesExpr",
+      "percentage",
+    ]);
+  });
+
+  it("8º e 9º ano: 4 operações básicas", () => {
+    for (const y of [8, 9]) {
       expect(getOperationsForGrade(y)).toEqual([
         "addition",
         "subtraction",
@@ -846,7 +1015,10 @@ describe("5º ano — BNCC", () => {
       const diff = Math.abs(q.correctAnswer - q.wrongAnswer);
       expect(diff).toBeGreaterThanOrEqual(1);
       // Offset adaptativo: max(2, ceil(answer/3)), limitado ao wrongOffset do ano (10)
-      const maxExpected = Math.max(2, Math.min(10, Math.ceil(q.correctAnswer / 3)));
+      const maxExpected = Math.max(
+        2,
+        Math.min(10, Math.ceil(q.correctAnswer / 3)),
+      );
       expect(diff).toBeLessThanOrEqual(maxExpected);
     }
   });
@@ -937,6 +1109,536 @@ describe("5º ano — BNCC", () => {
       // 4º ano não tem fração → deve sortear outra operação
       const sym = getSymbol(q.text);
       expect(["+", "-", "×", "÷"]).toContain(sym);
+    }
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════
+ * BNCC — 6º ano (Fundamental 2 — inicial) — Issue #47
+ * ══════════════════════════════════════════════════════════════ */
+
+describe("6º ano — BNCC", () => {
+  it("gera todos os 8 tipos de questão", () => {
+    const questions = generateForGrade(6, 1000);
+    const types = new Set(questions.map((q) => getSymbol(q.text)));
+    expect(types).toContain("+");
+    expect(types).toContain("-");
+    expect(types).toContain("×");
+    expect(types).toContain("÷");
+    expect(types).toContain("exp");
+    expect(types).toContain("dec");
+    expect(types).toContain("sameFrac");
+    expect(types).toContain("md");
+  });
+
+  /* ── Potenciação ── */
+
+  it("potenciação: formato correto (ex: 2³ = ?)", () => {
+    const questions = generateManyForGrade("exponentiation", 6, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^\d+[⁰¹²³⁴⁵⁶⁷⁸⁹]+ = \?$/);
+    }
+  });
+
+  it("potenciação: base entre 2 e 10", () => {
+    const questions = generateManyForGrade("exponentiation", 6, 500);
+    for (const q of questions) {
+      const { base } = parseExponentiation(q.text);
+      expect(base).toBeGreaterThanOrEqual(2);
+      expect(base).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("potenciação: expoente é 2 ou 3", () => {
+    const questions = generateManyForGrade("exponentiation", 6, 500);
+    const exps = new Set(
+      questions.map((q) => parseExponentiation(q.text).exp),
+    );
+    for (const e of exps) {
+      expect([2, 3]).toContain(e);
+    }
+    // Deve gerar ambos os expoentes
+    expect(exps).toContain(2);
+    expect(exps).toContain(3);
+  });
+
+  it("potenciação: resposta é base^exp", () => {
+    const questions = generateManyForGrade("exponentiation", 6, 500);
+    for (const q of questions) {
+      const { base, exp } = parseExponentiation(q.text);
+      expect(q.correctAnswer).toBe(Math.pow(base, exp));
+    }
+  });
+
+  it("potenciação: resultado é sempre inteiro positivo", () => {
+    const questions = generateManyForGrade("exponentiation", 6, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+      expect(q.correctAnswer).toBeGreaterThan(0);
+    }
+  });
+
+  /* ── Decimais ── */
+
+  it("decimal: formato correto (ex: 1,5 + 2,3 = ?)", () => {
+    const questions = generateManyForGrade("decimal", 6, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^\d+,\d+\s*[+\-]\s*\d+,\d+\s*=\s*\?$/);
+    }
+  });
+
+  it("decimal: operandos entre 1,0 e 9,9", () => {
+    const questions = generateManyForGrade("decimal", 6, 500);
+    for (const q of questions) {
+      const { a, b } = parseDecimal(q.text);
+      expect(a).toBeGreaterThanOrEqual(1.0);
+      expect(a).toBeLessThanOrEqual(9.9);
+      expect(b).toBeGreaterThanOrEqual(1.0);
+      expect(b).toBeLessThanOrEqual(9.9);
+    }
+  });
+
+  it("decimal: resultado correto (soma ou diferença)", () => {
+    const questions = generateManyForGrade("decimal", 6, 500);
+    for (const q of questions) {
+      const { a, op, b } = parseDecimal(q.text);
+      const expected = op === "+" ? a + b : a - b;
+      // Compara com tolerância para floating point
+      expect(Math.abs(q.correctAnswer - expected)).toBeLessThan(0.01);
+    }
+  });
+
+  it("decimal: resultado ≥ 0 para subtração", () => {
+    const questions = generateManyForGrade("decimal", 6, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("decimal: gera tanto + quanto - como operação", () => {
+    const questions = generateManyForGrade("decimal", 6, 500);
+    const ops = new Set(questions.map((q) => parseDecimal(q.text).op));
+    expect(ops).toContain("+");
+    expect(ops).toContain("-");
+  });
+
+  it("decimal: displayCorrect e displayWrong presentes com vírgula", () => {
+    const questions = generateManyForGrade("decimal", 6, 200);
+    for (const q of questions) {
+      expect(q.leftDisplay).toBeDefined();
+      expect(q.rightDisplay).toBeDefined();
+      // Ao menos um display contém vírgula
+      const displays = [q.leftDisplay!, q.rightDisplay!];
+      for (const d of displays) {
+        expect(d).toMatch(/^\d+,\d$/);
+      }
+    }
+  });
+
+  it("decimal: displayCorrect é diferente de displayWrong", () => {
+    const questions = generateManyForGrade("decimal", 6, 500);
+    for (const q of questions) {
+      expect(q.leftDisplay).not.toBe(q.rightDisplay);
+    }
+  });
+
+  /* ── Frações com mesmo denominador ── */
+
+  it("fração mesmo denom: formato correto com Unicode", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 200);
+    for (const q of questions) {
+      // "²⁄₅ + ¹⁄₅ = ?" ou "³⁄₈ − ¹⁄₈ = ?"
+      expect(q.text).toMatch(
+        /^[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄[₀₁₂₃₄₅₆₇₈₉]+\s*[+−]\s*[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄[₀₁₂₃₄₅₆₇₈₉]+\s*=\s*\?$/,
+      );
+    }
+  });
+
+  it("fração mesmo denom: ambas têm o mesmo denominador", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    for (const q of questions) {
+      const { d1, d2 } = parseSameDenomFraction(q.text);
+      expect(d1).toBe(d2);
+    }
+  });
+
+  it("fração mesmo denom: denominadores são 3, 4, 5, 6 ou 8", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    const denoms = new Set(
+      questions.map((q) => parseSameDenomFraction(q.text).d1),
+    );
+    for (const d of denoms) {
+      expect([3, 4, 5, 6, 8]).toContain(d);
+    }
+  });
+
+  it("fração mesmo denom: resultado (numerador) entre 1 e denominador", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    for (const q of questions) {
+      const { d1 } = parseSameDenomFraction(q.text);
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(1);
+      expect(q.correctAnswer).toBeLessThanOrEqual(d1);
+    }
+  });
+
+  it("fração mesmo denom: resposta correta confere", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    for (const q of questions) {
+      const { n1, op, n2 } = parseSameDenomFraction(q.text);
+      const expected = op === "+" ? n1 + n2 : n1 - n2;
+      expect(q.correctAnswer).toBe(expected);
+    }
+  });
+
+  it("fração mesmo denom: gera tanto + quanto − como operação", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    const ops = new Set(
+      questions.map((q) => parseSameDenomFraction(q.text).op),
+    );
+    expect(ops).toContain("+");
+    expect(ops).toContain("−");
+  });
+
+  it("fração mesmo denom: displayCorrect e displayWrong são frações Unicode", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 200);
+    for (const q of questions) {
+      expect(q.leftDisplay).toBeDefined();
+      expect(q.rightDisplay).toBeDefined();
+      // Verifica formato Unicode de fração
+      const regex = /^[⁰¹²³⁴⁵⁶⁷⁸⁹]+⁄[₀₁₂₃₄₅₆₇₈₉]+$/;
+      expect(q.leftDisplay).toMatch(regex);
+      expect(q.rightDisplay).toMatch(regex);
+    }
+  });
+
+  it("fração mesmo denom: display mantém o mesmo denominador para correto e errado", () => {
+    const questions = generateManyForGrade("sameDenomFraction", 6, 500);
+    for (const q of questions) {
+      const left = parseDisplayFraction(q.leftDisplay!);
+      const right = parseDisplayFraction(q.rightDisplay!);
+      expect(left.den).toBe(right.den);
+    }
+  });
+
+  /* ── Múltiplos e divisores ── */
+
+  it("múltiplos/divisores: formato correto", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^(Múltiplo|Divisor) de \d+ = \?$/);
+    }
+  });
+
+  it("múltiplos/divisores: gera ambos os subtipos", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 500);
+    const types = new Set(
+      questions.map((q) => parseMultDiv(q.text).type),
+    );
+    expect(types).toContain("Múltiplo");
+    expect(types).toContain("Divisor");
+  });
+
+  it("múltiplos: resposta correta é múltiplo da base", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 500);
+    for (const q of questions) {
+      const { type, base } = parseMultDiv(q.text);
+      if (type === "Múltiplo") {
+        expect(q.correctAnswer % base).toBe(0);
+      }
+    }
+  });
+
+  it("múltiplos: resposta errada NÃO é múltiplo da base", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 500);
+    for (const q of questions) {
+      const { type, base } = parseMultDiv(q.text);
+      if (type === "Múltiplo") {
+        expect(q.wrongAnswer % base).not.toBe(0);
+      }
+    }
+  });
+
+  it("divisores: resposta correta é divisor do número", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 500);
+    for (const q of questions) {
+      const { type, base } = parseMultDiv(q.text);
+      if (type === "Divisor") {
+        expect(base % q.correctAnswer).toBe(0);
+      }
+    }
+  });
+
+  it("divisores: resposta errada NÃO é divisor do número", () => {
+    const questions = generateManyForGrade("multiplesDivisors", 6, 500);
+    for (const q of questions) {
+      const { type, base } = parseMultDiv(q.text);
+      if (type === "Divisor") {
+        expect(base % q.wrongAnswer).not.toBe(0);
+      }
+    }
+  });
+
+  /* ── Regras gerais 6º ano ── */
+
+  it("left e right são sempre diferentes", () => {
+    const questions = generateForGrade(6, 500);
+    for (const q of questions) {
+      if (q.leftDisplay && q.rightDisplay) {
+        expect(q.leftDisplay).not.toBe(q.rightDisplay);
+      } else {
+        expect(q.leftValue).not.toBe(q.rightValue);
+      }
+    }
+  });
+
+  it("operação indisponível (negativeOps no 6º) cai em válida do ano", () => {
+    const questions = Array.from({ length: 50 }, () =>
+      generateQuestion("negativeOps", 6),
+    );
+    for (const q of questions) {
+      const sym = getSymbol(q.text);
+      expect(["+", "-", "×", "÷", "exp", "dec", "sameFrac", "md"]).toContain(
+        sym,
+      );
+    }
+  });
+});
+
+/* ══════════════════════════════════════════════════════════════
+ * BNCC — 7º ano (Fundamental 2 — inicial) — Issue #47
+ * ══════════════════════════════════════════════════════════════ */
+
+describe("7º ano — BNCC", () => {
+  it("gera todos os 8 tipos de questão", () => {
+    const questions = generateForGrade(7, 1000);
+    const types = new Set(questions.map((q) => getSymbol(q.text)));
+    expect(types).toContain("+");
+    expect(types).toContain("-");
+    expect(types).toContain("×");
+    expect(types).toContain("÷");
+    expect(types).toContain("neg");
+    expect(types).toContain("prop");
+    expect(types).toContain("paren");
+    expect(types).toContain("pct");
+  });
+
+  /* ── Números negativos ── */
+
+  it("negativos: formato correto (ex: −3 + 5 = ? ou −3 − 5 = ?)", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^−\d+\s*[+−]\s*\d+\s*=\s*\?$/);
+    }
+  });
+
+  it("negativos: operandos entre 1 e 10", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 500);
+    for (const q of questions) {
+      const { a, b } = parseNegative(q.text);
+      expect(a).toBeGreaterThanOrEqual(1);
+      expect(a).toBeLessThanOrEqual(10);
+      expect(b).toBeGreaterThanOrEqual(1);
+      expect(b).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("negativos: resposta correta confere", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 500);
+    for (const q of questions) {
+      const { a, op, b } = parseNegative(q.text);
+      const expected = op === "+" ? -a + b : -(a + b);
+      expect(q.correctAnswer).toBe(expected);
+    }
+  });
+
+  it("negativos: gera tanto + quanto − como operação", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 500);
+    const ops = new Set(questions.map((q) => parseNegative(q.text).op));
+    expect(ops).toContain("+");
+    expect(ops).toContain("−");
+  });
+
+  it("negativos: resposta pode ser negativa", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 500);
+    const hasNegative = questions.some((q) => q.correctAnswer < 0);
+    expect(hasNegative).toBe(true);
+  });
+
+  it("negativos: displayCorrect e displayWrong presentes", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 200);
+    for (const q of questions) {
+      expect(q.leftDisplay).toBeDefined();
+      expect(q.rightDisplay).toBeDefined();
+      expect(q.leftDisplay).not.toBe(q.rightDisplay);
+    }
+  });
+
+  it("negativos: display usa Unicode minus para valores negativos", () => {
+    const questions = generateManyForGrade("negativeOps", 7, 500);
+    for (const q of questions) {
+      if (q.correctAnswer < 0) {
+        const correctDisplay =
+          q.correctSide === "left" ? q.leftDisplay : q.rightDisplay;
+        expect(correctDisplay).toMatch(/^−\d+$/);
+      }
+    }
+  });
+
+  /* ── Proporções ── */
+
+  it("proporção: formato correto (ex: Se 2 → 6, 4 → ?)", () => {
+    const questions = generateManyForGrade("proportion", 7, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^Se \d+ → \d+, \d+ → \?$/);
+    }
+  });
+
+  it("proporção: resultado inteiro e correto", () => {
+    const questions = generateManyForGrade("proportion", 7, 500);
+    for (const q of questions) {
+      const { a, b, c } = parseProportion(q.text);
+      const ratio = b / a;
+      expect(Number.isInteger(ratio)).toBe(true);
+      expect(q.correctAnswer).toBe(c * ratio);
+    }
+  });
+
+  it("proporção: razão é 2, 3, 4 ou 5", () => {
+    const questions = generateManyForGrade("proportion", 7, 500);
+    const ratios = new Set(
+      questions.map((q) => {
+        const { a, b } = parseProportion(q.text);
+        return b / a;
+      }),
+    );
+    for (const r of ratios) {
+      expect([2, 3, 4, 5]).toContain(r);
+    }
+  });
+
+  it("proporção: c ≠ b (evita confusão visual)", () => {
+    const questions = generateManyForGrade("proportion", 7, 500);
+    for (const q of questions) {
+      const { b, c } = parseProportion(q.text);
+      expect(c).not.toBe(b);
+    }
+  });
+
+  /* ── Expressões com parênteses ── */
+
+  it("parênteses: formato correto (ex: (3 + 2) × 4 = ?)", () => {
+    const questions = generateManyForGrade("parenthesesExpr", 7, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(
+        /^\(\d+\s*[+−]\s*\d+\)\s*×\s*\d+\s*=\s*\?$/,
+      );
+    }
+  });
+
+  it("parênteses: resultado correto (resolve parênteses primeiro)", () => {
+    const questions = generateManyForGrade("parenthesesExpr", 7, 500);
+    for (const q of questions) {
+      const { a, op1, b, c } = parseParentheses(q.text);
+      const inner = op1 === "+" ? a + b : a - b;
+      expect(q.correctAnswer).toBe(inner * c);
+    }
+  });
+
+  it("parênteses: resultado sempre ≥ 0", () => {
+    const questions = generateManyForGrade("parenthesesExpr", 7, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("parênteses: operandos entre 2 e 10", () => {
+    const questions = generateManyForGrade("parenthesesExpr", 7, 500);
+    for (const q of questions) {
+      const { a, b, c } = parseParentheses(q.text);
+      expect(a).toBeGreaterThanOrEqual(2);
+      expect(a).toBeLessThanOrEqual(10);
+      expect(b).toBeGreaterThanOrEqual(2);
+      expect(b).toBeLessThanOrEqual(10);
+      expect(c).toBeGreaterThanOrEqual(2);
+      expect(c).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("parênteses: resultado é sempre inteiro", () => {
+    const questions = generateManyForGrade("parenthesesExpr", 7, 500);
+    for (const q of questions) {
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  /* ── Porcentagens ── */
+
+  it("porcentagem: formato correto (ex: 10% de 200 = ?)", () => {
+    const questions = generateManyForGrade("percentage", 7, 200);
+    for (const q of questions) {
+      expect(q.text).toMatch(/^\d+% de \d+ = \?$/);
+    }
+  });
+
+  it("porcentagem: usa porcentagens de 10, 20, 25, 50 ou 75%", () => {
+    const questions = generateManyForGrade("percentage", 7, 500);
+    const pcts = new Set(
+      questions.map((q) => parsePercentage(q.text).pct),
+    );
+    for (const p of pcts) {
+      expect([10, 20, 25, 50, 75]).toContain(p);
+    }
+    // Deve gerar variedade
+    expect(pcts.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("porcentagem: resultado correto e inteiro", () => {
+    const questions = generateManyForGrade("percentage", 7, 500);
+    for (const q of questions) {
+      const { pct, whole } = parsePercentage(q.text);
+      expect(q.correctAnswer).toBe((whole * pct) / 100);
+      expect(Number.isInteger(q.correctAnswer)).toBe(true);
+    }
+  });
+
+  it("porcentagem: resultado > 0", () => {
+    const questions = generateManyForGrade("percentage", 7, 500);
+    for (const q of questions) {
+      expect(q.correctAnswer).toBeGreaterThan(0);
+    }
+  });
+
+  it("porcentagem: inteiro entre 20 e 500", () => {
+    const questions = generateManyForGrade("percentage", 7, 500);
+    for (const q of questions) {
+      const { whole } = parsePercentage(q.text);
+      expect(whole).toBeGreaterThanOrEqual(20);
+      expect(whole).toBeLessThanOrEqual(500);
+    }
+  });
+
+  /* ── Regras gerais 7º ano ── */
+
+  it("left e right são sempre diferentes", () => {
+    const questions = generateForGrade(7, 500);
+    for (const q of questions) {
+      if (q.leftDisplay && q.rightDisplay) {
+        expect(q.leftDisplay).not.toBe(q.rightDisplay);
+      } else {
+        expect(q.leftValue).not.toBe(q.rightValue);
+      }
+    }
+  });
+
+  it("operação indisponível (exponentiation no 7º) cai em válida do ano", () => {
+    const questions = Array.from({ length: 50 }, () =>
+      generateQuestion("exponentiation", 7),
+    );
+    for (const q of questions) {
+      const sym = getSymbol(q.text);
+      expect(["+", "-", "×", "÷", "neg", "prop", "paren", "pct"]).toContain(
+        sym,
+      );
     }
   });
 });

--- a/src/lib/__tests__/speech.test.ts
+++ b/src/lib/__tests__/speech.test.ts
@@ -2,12 +2,20 @@ import { describe, it, expect } from "vitest";
 import { buildNarration } from "../speech";
 
 /**
- * Testes do buildNarration (#46).
+ * Testes do buildNarration (#46 + #47).
  *
  * Verifica que a narração por voz funciona para:
  * 1. Operações simples (adição, subtração, multiplicação, divisão)
- * 2. Frações (½, ¼, ¾)
- * 3. Expressões com duas operações
+ * 2. Frações (½, ¼, ¾) — 5º ano
+ * 3. Expressões com duas operações — 5º ano
+ * 4. Potenciação — 6º ano
+ * 5. Decimais — 6º ano
+ * 6. Frações mesmo denominador — 6º ano
+ * 7. Múltiplos/divisores — 6º ano
+ * 8. Negativos — 7º ano
+ * 9. Proporções — 7º ano
+ * 10. Parênteses — 7º ano
+ * 11. Porcentagens — 7º ano
  */
 describe("buildNarration", () => {
   /* ── Operações simples ── */
@@ -67,6 +75,130 @@ describe("buildNarration", () => {
   it("expressão com -: narra corretamente", () => {
     expect(buildNarration("5 × 3 - 4 = ?", 11, 13)).toBe(
       "Quanto é 5 vezes 3 menos 4? À esquerda, 11. À direita, 13.",
+    );
+  });
+
+  /* ── Potenciação (#47 — 6º ano) ── */
+
+  it("potenciação 2²: narra 'elevado a 2'", () => {
+    expect(buildNarration("2² = ?", 4, 6)).toBe(
+      "Quanto é 2 elevado a 2? À esquerda, 4. À direita, 6.",
+    );
+  });
+
+  it("potenciação 5³: narra 'elevado a 3'", () => {
+    expect(buildNarration("5³ = ?", 125, 120)).toBe(
+      "Quanto é 5 elevado a 3? À esquerda, 125. À direita, 120.",
+    );
+  });
+
+  it("potenciação 10²: narra base 10", () => {
+    expect(buildNarration("10² = ?", 100, 90)).toBe(
+      "Quanto é 10 elevado a 2? À esquerda, 100. À direita, 90.",
+    );
+  });
+
+  /* ── Decimais (#47 — 6º ano) ── */
+
+  it("decimal com +: narra vírgula", () => {
+    expect(buildNarration("1,5 + 2,3 = ?", "3,8", "4,1")).toBe(
+      "Quanto é 1 vírgula 5 mais 2 vírgula 3? À esquerda, 3 vírgula 8. À direita, 4 vírgula 1.",
+    );
+  });
+
+  it("decimal com -: narra vírgula e menos", () => {
+    expect(buildNarration("5,7 - 2,4 = ?", "3,3", "3,5")).toBe(
+      "Quanto é 5 vírgula 7 menos 2 vírgula 4? À esquerda, 3 vírgula 3. À direita, 3 vírgula 5.",
+    );
+  });
+
+  /* ── Frações mesmo denominador (#47 — 6º ano) ── */
+
+  it("fração mesmo denom +: narra numeradores e denominadores", () => {
+    expect(buildNarration("²⁄₅ + ¹⁄₅ = ?", "³⁄₅", "⁴⁄₅")).toBe(
+      "Quanto é 2 quintos mais 1 quinto? À esquerda, 3 quintos. À direita, 4 quintos.",
+    );
+  });
+
+  it("fração mesmo denom −: narra subtração", () => {
+    expect(buildNarration("³⁄₄ − ¹⁄₄ = ?", "²⁄₄", "³⁄₄")).toBe(
+      "Quanto é 3 quartos menos 1 quarto? À esquerda, 2 quartos. À direita, 3 quartos.",
+    );
+  });
+
+  it("fração com denominador 8: narra 'oitavos'", () => {
+    expect(buildNarration("⁵⁄₈ + ²⁄₈ = ?", "⁷⁄₈", "⁶⁄₈")).toBe(
+      "Quanto é 5 oitavos mais 2 oitavos? À esquerda, 7 oitavos. À direita, 6 oitavos.",
+    );
+  });
+
+  it("fração com denominador 3: narra 'terço' (singular) e 'terços'", () => {
+    expect(buildNarration("¹⁄₃ + ¹⁄₃ = ?", "²⁄₃", "¹⁄₃")).toBe(
+      "Quanto é 1 terço mais 1 terço? À esquerda, 2 terços. À direita, 1 terço.",
+    );
+  });
+
+  /* ── Múltiplos e divisores (#47 — 6º ano) ── */
+
+  it("múltiplo: narra 'qual é o múltiplo de'", () => {
+    expect(buildNarration("Múltiplo de 6 = ?", 18, 16)).toBe(
+      "Qual é o múltiplo de 6? À esquerda, 18. À direita, 16.",
+    );
+  });
+
+  it("divisor: narra 'qual é o divisor de'", () => {
+    expect(buildNarration("Divisor de 24 = ?", 6, 5)).toBe(
+      "Qual é o divisor de 24? À esquerda, 6. À direita, 5.",
+    );
+  });
+
+  /* ── Negativos (#47 — 7º ano) ── */
+
+  it("negativo com +: narra 'menos' para o número negativo", () => {
+    expect(buildNarration("−3 + 5 = ?", "2", "4")).toBe(
+      "Quanto é menos 3 mais 5? À esquerda, 2. À direita, 4.",
+    );
+  });
+
+  it("negativo com −: narra 'menos' duas vezes", () => {
+    expect(buildNarration("−4 − 3 = ?", "−7", "−5")).toBe(
+      "Quanto é menos 4 menos 3? À esquerda, menos 7. À direita, menos 5.",
+    );
+  });
+
+  /* ── Proporções (#47 — 7º ano) ── */
+
+  it("proporção: narra 'se X dá Y, quanto dá Z'", () => {
+    expect(buildNarration("Se 2 → 6, 4 → ?", 12, 10)).toBe(
+      "Se 2 dá 6, quanto dá 4? À esquerda, 12. À direita, 10.",
+    );
+  });
+
+  /* ── Expressões com parênteses (#47 — 7º ano) ── */
+
+  it("parênteses com +: narra abre/fecha parênteses", () => {
+    expect(buildNarration("(3 + 2) × 4 = ?", 20, 18)).toBe(
+      "Quanto é, abre parênteses, 3 mais 2, fecha parênteses, vezes 4? À esquerda, 20. À direita, 18.",
+    );
+  });
+
+  it("parênteses com −: narra subtração dentro dos parênteses", () => {
+    expect(buildNarration("(7 − 3) × 5 = ?", 20, 25)).toBe(
+      "Quanto é, abre parênteses, 7 menos 3, fecha parênteses, vezes 5? À esquerda, 20. À direita, 25.",
+    );
+  });
+
+  /* ── Porcentagens (#47 — 7º ano) ── */
+
+  it("porcentagem: narra 'X por cento de Y'", () => {
+    expect(buildNarration("10% de 200 = ?", 20, 25)).toBe(
+      "Quanto é 10 por cento de 200? À esquerda, 20. À direita, 25.",
+    );
+  });
+
+  it("porcentagem 50%: narra corretamente", () => {
+    expect(buildNarration("50% de 80 = ?", 40, 35)).toBe(
+      "Quanto é 50 por cento de 80? À esquerda, 40. À direita, 35.",
     );
   });
 

--- a/src/lib/generateQuestion.ts
+++ b/src/lib/generateQuestion.ts
@@ -7,8 +7,8 @@
  *
  * Regras gerais:
  * - Divisões sempre com resultado inteiro
- * - Frações sempre com resultado inteiro
- * - Expressões nunca com resultado negativo
+ * - Frações sempre com resultado inteiro (5º ano) ou fração simples (6º)
+ * - Expressões nunca com resultado negativo (exceto 7º ano: negativeOps)
  * - Resposta incorreta plausível (próxima da correta)
  * - Posição da resposta correta (esquerda/direita) aleatória
  * - As duas opções são sempre diferentes
@@ -21,6 +21,10 @@
  * BNCC — Fundamental 1 (anos avançados):
  * - 4º ano: tabuada completa até 10, números até 1000
  * - 5º ano: números até 10.000, frações (½, ¼, ¾), expressões simples
+ *
+ * BNCC — Fundamental 2 (inicial):
+ * - 6º ano: potenciação, decimais, frações mesmo denominador, múltiplos/divisores
+ * - 7º ano: negativos, proporções, expressões com parênteses, porcentagens
  */
 
 export type Operation =
@@ -29,7 +33,17 @@ export type Operation =
   | "multiplication"
   | "division"
   | "fraction"
-  | "expression";
+  | "expression"
+  /* 6º ano */
+  | "exponentiation"
+  | "decimal"
+  | "sameDenomFraction"
+  | "multiplesDivisors"
+  /* 7º ano */
+  | "negativeOps"
+  | "proportion"
+  | "parenthesesExpr"
+  | "percentage";
 
 export interface MathQuestion {
   /** Texto da pergunta, ex: "12 + 15 = ?" */
@@ -44,6 +58,15 @@ export interface MathQuestion {
   leftValue: number;
   /** Valor exibido na opção direita */
   rightValue: number;
+  /**
+   * Display string para a opção esquerda (sobrescreve leftValue quando definida).
+   * Usado para decimais ("3,8"), frações ("³⁄₅") e negativos ("−8").
+   */
+  leftDisplay?: string;
+  /**
+   * Display string para a opção direita (sobrescreve rightValue quando definida).
+   */
+  rightDisplay?: string;
 }
 
 /* ── Helpers ─────────────────────────────────────────────────── */
@@ -60,17 +83,72 @@ function pick<T>(arr: T[]): T {
 
 /**
  * Gera uma resposta incorreta plausível.
- * Offset de ±1 a ±maxOffset, garantindo que seja diferente da correta e ≥ 0.
+ * Offset de ±1 a ±maxOffset, garantindo que seja diferente da correta.
+ * Se allowNegative = false (padrão), resultado ≥ 0.
  */
-function generateWrongAnswer(correct: number, maxOffset: number = 5): number {
+function generateWrongAnswer(
+  correct: number,
+  maxOffset: number = 5,
+  allowNegative: boolean = false,
+): number {
   const maxAttempts = 20;
   for (let i = 0; i < maxAttempts; i++) {
     const offset = randInt(1, maxOffset) * pick([1, -1]);
     const wrong = correct + offset;
-    if (wrong !== correct && wrong >= 0) return wrong;
+    if (wrong !== correct && (allowNegative || wrong >= 0)) return wrong;
   }
-  // Fallback: sempre diferente e ≥ 0
-  return correct >= 1 ? correct - 1 : correct + 1;
+  // Fallback: sempre diferente
+  return correct >= 1 || allowNegative ? correct - 1 : correct + 1;
+}
+
+/** Máximo divisor comum (para porcentagens). */
+function gcd(a: number, b: number): number {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+}
+
+/* ── Unicode helpers ─────────────────────────────────────────── */
+
+const SUPERSCRIPTS = "⁰¹²³⁴⁵⁶⁷⁸⁹";
+const SUBSCRIPTS = "₀₁₂₃₄₅₆₇₈₉";
+
+/** Converte número para dígitos Unicode sobrescritos: 23 → "²³" */
+function toSuperscript(n: number): string {
+  return String(n)
+    .split("")
+    .map((d) => SUPERSCRIPTS[Number(d)])
+    .join("");
+}
+
+/** Converte número para dígitos Unicode subscritos: 5 → "₅" */
+function toSubscript(n: number): string {
+  return String(n)
+    .split("")
+    .map((d) => SUBSCRIPTS[Number(d)])
+    .join("");
+}
+
+/** Formata número com 1 casa decimal no padrão brasileiro: 3.8 → "3,8" */
+function formatDecimalBR(n: number): string {
+  return n.toFixed(1).replace(".", ",");
+}
+
+/** Formata número com sinal Unicode menos: -8 → "−8", 2 → "2" */
+function formatNegative(n: number): string {
+  return n < 0 ? `−${Math.abs(n)}` : String(n);
+}
+
+/** Retorna todos os divisores de n (excluindo 1 e n). */
+function getDivisorsInner(n: number): number[] {
+  const divs: number[] = [];
+  for (let i = 2; i < n; i++) {
+    if (n % i === 0) divs.push(i);
+  }
+  return divs;
 }
 
 /* ═══════════════════════════════════════════════════════
@@ -97,7 +175,7 @@ const FRACTIONS_5TH: FractionDef[] = [
 ];
 
 /* ═══════════════════════════════════════════════════════
- * Configuração por ano escolar (#44 + #45 + #46 BNCC)
+ * Configuração por ano escolar (#44 + #45 + #46 + #47 BNCC)
  * ═══════════════════════════════════════════════════════ */
 
 /**
@@ -114,6 +192,20 @@ const FRACTIONS_5TH: FractionDef[] = [
  * - `fractions`: (opcional) definições de frações disponíveis
  * - `fractionWholeRange`: (opcional) [min, max] do número inteiro para frações
  * - `exprRange`: (opcional) [min, max] dos operandos para expressões
+ *
+ * Campos do 6º ano (#47):
+ * - `expBases`: [min, max] para a base de potenciação
+ * - `expExponents`: expoentes permitidos (ex: [2, 3])
+ * - `decimalRange`: [min, max] dos operandos em décimos (ex: [10, 99] → 1,0 a 9,9)
+ * - `sameDenomDenominators`: denominadores permitidos (ex: [3, 4, 5, 6, 8])
+ * - `multiplesRange`: [min, max] para a base de múltiplos/divisores
+ *
+ * Campos do 7º ano (#47):
+ * - `negativeRange`: [min, max] dos operandos positivos (exibidos com sinal −)
+ * - `proportionRatios`: razões permitidas (ex: [2, 3, 4, 5])
+ * - `parenthesesRange`: [min, max] dos operandos em expressões com parênteses
+ * - `percentages`: porcentagens permitidas (ex: [10, 20, 25, 50, 75])
+ * - `percentageWholeRange`: [min, max] do número inteiro para porcentagens
  */
 interface GradeConfig {
   operations: Operation[];
@@ -127,6 +219,18 @@ interface GradeConfig {
   fractions?: FractionDef[];
   fractionWholeRange?: [number, number];
   exprRange?: [number, number];
+  /* 6º ano */
+  expBases?: [number, number];
+  expExponents?: number[];
+  decimalRange?: [number, number];
+  sameDenomDenominators?: number[];
+  multiplesRange?: [number, number];
+  /* 7º ano */
+  negativeRange?: [number, number];
+  proportionRatios?: number[];
+  parenthesesRange?: [number, number];
+  percentages?: number[];
+  percentageWholeRange?: [number, number];
 }
 
 const GRADE_CONFIGS: Record<number, GradeConfig> = {
@@ -212,26 +316,72 @@ const GRADE_CONFIGS: Record<number, GradeConfig> = {
     exprRange: [2, 10],
   },
 
-  /* ── Fundamental 2 ─────────────────────────────────────────── */
+  /* ── Fundamental 2 — inicial (#47) ─────────────────────────── */
 
-  /* 6º ano — números maiores */
+  /**
+   * 6º ano — BNCC:
+   * - Potenciação simples (ex: 2³ = 8)
+   * - Operações com decimais (ex: 1,5 + 2,3 = 3,8)
+   * - Frações: adição/subtração com mesmo denominador (ex: ²⁄₅ + ¹⁄₅ = ³⁄₅)
+   * - Múltiplos e divisores (ex: múltiplo de 6 = ?)
+   * - Mantém as 4 operações básicas com números maiores
+   */
   6: {
-    operations: ["addition", "subtraction", "multiplication", "division"],
+    operations: [
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "exponentiation",
+      "decimal",
+      "sameDenomFraction",
+      "multiplesDivisors",
+    ],
     add: [100, 999, 100, 999],
     sub: [200, 999, 100],
     mul: [5, 20, 5, 20],
     div: [5, 20, 3, 15],
     wrongOffset: 10,
+    expBases: [2, 10],
+    expExponents: [2, 3],
+    decimalRange: [10, 99],
+    sameDenomDenominators: [3, 4, 5, 6, 8],
+    multiplesRange: [2, 12],
   },
-  /* 7º ano */
+
+  /**
+   * 7º ano — BNCC:
+   * - Números negativos: operações básicas (ex: −3 + 5 = 2)
+   * - Proporções simples (ex: Se 2 → 6, 4 → ?)
+   * - Expressões com parênteses (ex: (3 + 2) × 4 = 20)
+   * - Porcentagens simples (ex: 10% de 200 = 20)
+   * - Mantém as 4 operações básicas com números maiores
+   */
   7: {
-    operations: ["addition", "subtraction", "multiplication", "division"],
+    operations: [
+      "addition",
+      "subtraction",
+      "multiplication",
+      "division",
+      "negativeOps",
+      "proportion",
+      "parenthesesExpr",
+      "percentage",
+    ],
     add: [200, 999, 200, 999],
     sub: [300, 999, 100],
     mul: [10, 25, 5, 20],
     div: [5, 25, 3, 20],
     wrongOffset: 10,
+    negativeRange: [1, 10],
+    proportionRatios: [2, 3, 4, 5],
+    parenthesesRange: [2, 10],
+    percentages: [10, 20, 25, 50, 75],
+    percentageWholeRange: [20, 500],
   },
+
+  /* ── Fundamental 2 — avançado ──────────────────────────────── */
+
   /* 8º ano */
   8: {
     operations: ["addition", "subtraction", "multiplication", "division"],
@@ -259,6 +409,14 @@ interface GeneratorResult {
   answer: number;
   /** Offset custom para a resposta errada (sobrescreve cfg.wrongOffset). */
   wrongOffset?: number;
+  /** Resposta errada pré-calculada (bypassa generateWrongAnswer). */
+  wrongAnswer?: number;
+  /** Display string para a resposta correta. */
+  displayCorrect?: string;
+  /** Display string para a resposta errada. */
+  displayWrong?: string;
+  /** Se true, a resposta errada pode ser negativa. */
+  allowNegativeWrong?: boolean;
 }
 
 /* ── Geradores por operação (parametrizados) ─────────────────── */
@@ -332,9 +490,16 @@ function generateFraction(cfg: GradeConfig): GeneratorResult {
   const answer = (whole * frac.numerator) / frac.denominator;
 
   // Offset proporcional à resposta (mín 2, máx wrongOffset do ano)
-  const adaptiveOffset = Math.max(2, Math.min(cfg.wrongOffset, Math.ceil(answer / 3)));
+  const adaptiveOffset = Math.max(
+    2,
+    Math.min(cfg.wrongOffset, Math.ceil(answer / 3)),
+  );
 
-  return { text: `${frac.symbol} de ${whole} = ?`, answer, wrongOffset: adaptiveOffset };
+  return {
+    text: `${frac.symbol} de ${whole} = ?`,
+    answer,
+    wrongOffset: adaptiveOffset,
+  };
 }
 
 /**
@@ -369,6 +534,333 @@ function generateExpression(cfg: GradeConfig): GeneratorResult {
   };
 }
 
+/* ═══════════════════════════════════════════════════════
+ * Geradores do 6º ano (#47)
+ * ═══════════════════════════════════════════════════════ */
+
+/**
+ * Potenciação simples.
+ *
+ * Exemplo: "2³ = ?" → resposta 8.
+ * Exibe o expoente com sobrescrito Unicode para acessibilidade visual.
+ * Narração: "2 elevado a 3".
+ */
+function generateExponentiation(cfg: GradeConfig): GeneratorResult {
+  const [baseMin, baseMax] = cfg.expBases ?? [2, 10];
+  const exponents = cfg.expExponents ?? [2, 3];
+
+  const base = randInt(baseMin, baseMax);
+  const exp = pick(exponents);
+  const answer = Math.pow(base, exp);
+
+  return {
+    text: `${base}${toSuperscript(exp)} = ?`,
+    answer,
+  };
+}
+
+/**
+ * Operações com decimais (1 casa decimal, formato brasileiro).
+ *
+ * Exemplo: "1,5 + 2,3 = ?" → resposta 3,8.
+ * Toda aritmética é feita em décimos (inteiros) para evitar
+ * imprecisão de ponto flutuante.
+ *
+ * Ambas as opções de resposta exibem display com vírgula.
+ */
+function generateDecimal(cfg: GradeConfig): GeneratorResult {
+  const [min10, max10] = cfg.decimalRange ?? [10, 99];
+  const isAdd = pick([true, false]);
+
+  let a10: number, b10: number, result10: number;
+
+  if (isAdd) {
+    a10 = randInt(min10, max10);
+    b10 = randInt(min10, max10);
+    result10 = a10 + b10;
+  } else {
+    a10 = randInt(min10, max10);
+    b10 = randInt(min10, a10); // resultado ≥ 0
+    result10 = a10 - b10;
+  }
+
+  const a = a10 / 10;
+  const b = b10 / 10;
+  const answer = result10 / 10;
+
+  const op = isAdd ? "+" : "-";
+  const text = `${formatDecimalBR(a)} ${op} ${formatDecimalBR(b)} = ?`;
+
+  // Resposta errada: offset de ±1 a ±3 em décimos
+  let wrong10 = result10;
+  for (let i = 0; i < 20; i++) {
+    const offset = randInt(1, 3) * pick([1, -1]);
+    const candidate = result10 + offset;
+    if (candidate !== result10 && candidate >= 0) {
+      wrong10 = candidate;
+      break;
+    }
+  }
+  if (wrong10 === result10) wrong10 = result10 + 1;
+
+  const wrongAnswer = wrong10 / 10;
+
+  return {
+    text,
+    answer,
+    wrongAnswer,
+    displayCorrect: formatDecimalBR(answer),
+    displayWrong: formatDecimalBR(wrongAnswer),
+  };
+}
+
+/**
+ * Frações com mesmo denominador (adição e subtração).
+ *
+ * Exemplo: "²⁄₅ + ¹⁄₅ = ?" → resposta ³⁄₅.
+ * O resultado é uma fração própria ou igual a 1 (≤ denominador).
+ * Exibe numeradores e denominadores com Unicode sobrescrito/subscrito.
+ *
+ * A resposta interna (correctAnswer) é o numerador do resultado,
+ * facilitando a geração do distrator (numerador ± 1).
+ */
+function generateSameDenomFraction(cfg: GradeConfig): GeneratorResult {
+  const denoms = cfg.sameDenomDenominators ?? [3, 4, 5, 6, 8];
+  const d = pick(denoms);
+  const isAdd = pick([true, false]);
+
+  let n1: number, n2: number, resultNum: number;
+
+  if (isAdd) {
+    // n1 + n2 ≤ d (fração própria ou = 1)
+    n1 = randInt(1, d - 1);
+    n2 = randInt(1, d - n1);
+    resultNum = n1 + n2;
+  } else {
+    // n1 > n2, resultado > 0
+    n1 = randInt(2, d - 1);
+    n2 = randInt(1, n1 - 1);
+    resultNum = n1 - n2;
+  }
+
+  const opChar = isAdd ? "+" : "−";
+  const text = `${toSuperscript(n1)}⁄${toSubscript(d)} ${opChar} ${toSuperscript(n2)}⁄${toSubscript(d)} = ?`;
+
+  // Distrator: numerador ± 1, limitado a [1, d]
+  let wrongNum = resultNum + pick([1, -1]);
+  if (wrongNum === resultNum || wrongNum < 1) wrongNum = resultNum + 1;
+  if (wrongNum > d) wrongNum = resultNum - 1;
+  if (wrongNum < 1) wrongNum = 1;
+  // Garante diferente
+  if (wrongNum === resultNum) wrongNum = resultNum === d ? d - 1 : resultNum + 1;
+
+  return {
+    text,
+    answer: resultNum,
+    wrongAnswer: wrongNum,
+    displayCorrect: `${toSuperscript(resultNum)}⁄${toSubscript(d)}`,
+    displayWrong: `${toSuperscript(wrongNum)}⁄${toSubscript(d)}`,
+  };
+}
+
+/**
+ * Múltiplos e divisores.
+ *
+ * Dois subtipos alternados:
+ * - "Múltiplo de 6 = ?" → opção correta é múltiplo, incorreta não é
+ * - "Divisor de 24 = ?" → opção correta é divisor, incorreta não é
+ *
+ * Distratores são números próximos que NÃO são múltiplos/divisores,
+ * o que exige raciocínio e não apenas aproximação numérica.
+ */
+function generateMultiplesDivisors(cfg: GradeConfig): GeneratorResult {
+  const [min, max] = cfg.multiplesRange ?? [2, 12];
+
+  if (pick([true, false])) {
+    /* ── Múltiplo ── */
+    const base = randInt(min, max);
+    const multiplier = randInt(2, 10);
+    const answer = base * multiplier;
+
+    // Distrator: número próximo que NÃO é múltiplo de base
+    let wrong = answer + 1;
+    for (let offset = 1; offset <= 5; offset++) {
+      for (const dir of [1, -1]) {
+        const candidate = answer + offset * dir;
+        if (candidate > 0 && candidate % base !== 0) {
+          wrong = candidate;
+          offset = 6; // break outer
+          break;
+        }
+      }
+    }
+
+    return { text: `Múltiplo de ${base} = ?`, answer, wrongAnswer: wrong };
+  } else {
+    /* ── Divisor ── */
+    // Números com vários divisores internos
+    const numbers = [12, 18, 20, 24, 30, 36, 48, 60];
+    const n = pick(numbers);
+    const divisors = getDivisorsInner(n);
+    if (divisors.length === 0) {
+      // Fallback raro: troca para múltiplo
+      return generateMultiplesDivisors(cfg);
+    }
+
+    const answer = pick(divisors);
+
+    // Distrator: número próximo que NÃO é divisor de n
+    let wrong = answer + 1;
+    for (let offset = 1; offset <= 5; offset++) {
+      for (const dir of [1, -1]) {
+        const candidate = answer + offset * dir;
+        if (candidate > 1 && n % candidate !== 0) {
+          wrong = candidate;
+          offset = 6; // break outer
+          break;
+        }
+      }
+    }
+
+    return { text: `Divisor de ${n} = ?`, answer, wrongAnswer: wrong };
+  }
+}
+
+/* ═══════════════════════════════════════════════════════
+ * Geradores do 7º ano (#47)
+ * ═══════════════════════════════════════════════════════ */
+
+/**
+ * Operações com números negativos.
+ *
+ * Formatos:
+ * - "−a + b = ?" (negativo + positivo)
+ * - "−a − b = ?" (negativo − positivo, resultado sempre negativo)
+ *
+ * Respostas podem ser negativas. Exibe números negativos com
+ * sinal Unicode (−) para clareza visual.
+ */
+function generateNegativeOps(cfg: GradeConfig): GeneratorResult {
+  const [min, max] = cfg.negativeRange ?? [1, 10];
+
+  const a = randInt(min, max);
+  const b = randInt(min, max);
+
+  let answer: number;
+  let text: string;
+
+  if (pick([true, false])) {
+    // −a + b
+    answer = -a + b;
+    text = `−${a} + ${b} = ?`;
+  } else {
+    // −a − b (sempre negativo)
+    answer = -(a + b);
+    text = `−${a} − ${b} = ?`;
+  }
+
+  // Gera resposta errada permitindo negativo
+  const maxOffset = cfg.wrongOffset;
+  let wrongAnswer = answer + 1;
+  for (let i = 0; i < 20; i++) {
+    const offset = randInt(1, maxOffset) * pick([1, -1]);
+    const candidate = answer + offset;
+    if (candidate !== answer) {
+      wrongAnswer = candidate;
+      break;
+    }
+  }
+
+  return {
+    text,
+    answer,
+    wrongAnswer,
+    displayCorrect: formatNegative(answer),
+    displayWrong: formatNegative(wrongAnswer),
+  };
+}
+
+/**
+ * Proporções simples.
+ *
+ * Exemplo: "Se 2 → 6, 4 → ?" → resposta 12.
+ * O aluno identifica a razão (×3) e aplica ao novo valor.
+ * Sempre com resultado inteiro.
+ */
+function generateProportion(cfg: GradeConfig): GeneratorResult {
+  const ratios = cfg.proportionRatios ?? [2, 3, 4, 5];
+  const ratio = pick(ratios);
+
+  const a = randInt(2, 5);
+  const b = a * ratio;
+
+  // c é um múltiplo de a (diferente de a e de b)
+  const multipliers = [2, 3, 4, 5].filter((m) => m * a !== b && m !== 1);
+  const multiplier = pick(multipliers.length > 0 ? multipliers : [2, 3]);
+  const c = a * multiplier;
+  const answer = c * ratio;
+
+  return {
+    text: `Se ${a} → ${b}, ${c} → ?`,
+    answer,
+  };
+}
+
+/**
+ * Expressões com parênteses.
+ *
+ * Exemplo: "(3 + 2) × 4 = ?" → resposta 20.
+ * Os parênteses mudam a ordem de operações — o aluno deve
+ * resolver o que está dentro primeiro.
+ *
+ * Formatos: (a + b) × c ou (a − b) × c (subtração só se a > b).
+ */
+function generateParenthesesExpr(cfg: GradeConfig): GeneratorResult {
+  const [min, max] = cfg.parenthesesRange ?? [2, 10];
+
+  const a = randInt(min, max);
+  const b = randInt(min, max);
+  const c = randInt(min, max);
+
+  if (pick([true, false]) && a > b) {
+    return {
+      text: `(${a} − ${b}) × ${c} = ?`,
+      answer: (a - b) * c,
+    };
+  }
+
+  return {
+    text: `(${a} + ${b}) × ${c} = ?`,
+    answer: (a + b) * c,
+  };
+}
+
+/**
+ * Porcentagens simples.
+ *
+ * Exemplo: "10% de 200 = ?" → resposta 20.
+ * O inteiro é sempre escolhido para que o resultado seja inteiro.
+ * Porcentagens usadas: 10%, 20%, 25%, 50%, 75%.
+ */
+function generatePercentage(cfg: GradeConfig): GeneratorResult {
+  const pcts = cfg.percentages ?? [10, 20, 25, 50, 75];
+  const pct = pick(pcts);
+  const [wholeMin, wholeMax] = cfg.percentageWholeRange ?? [20, 500];
+
+  // Factor mínimo do inteiro para resultado inteiro
+  const factor = 100 / gcd(pct, 100);
+  const minM = Math.ceil(wholeMin / factor);
+  const maxM = Math.floor(wholeMax / factor);
+  const whole = randInt(minM, maxM) * factor;
+
+  const answer = (whole * pct) / 100;
+
+  return {
+    text: `${pct}% de ${whole} = ?`,
+    answer,
+  };
+}
+
 /* ── Função principal ────────────────────────────────────────── */
 
 const generators: Record<Operation, (cfg: GradeConfig) => GeneratorResult> = {
@@ -378,6 +870,16 @@ const generators: Record<Operation, (cfg: GradeConfig) => GeneratorResult> = {
   division: generateDivision,
   fraction: generateFraction,
   expression: generateExpression,
+  /* 6º ano */
+  exponentiation: generateExponentiation,
+  decimal: generateDecimal,
+  sameDenomFraction: generateSameDenomFraction,
+  multiplesDivisors: generateMultiplesDivisors,
+  /* 7º ano */
+  negativeOps: generateNegativeOps,
+  proportion: generateProportion,
+  parenthesesExpr: generateParenthesesExpr,
+  percentage: generatePercentage,
 };
 
 /**
@@ -386,7 +888,10 @@ const generators: Record<Operation, (cfg: GradeConfig) => GeneratorResult> = {
  * @param operation — operação específica, ou omita para sortear entre as disponíveis no ano.
  * @param schoolYear — ano escolar (1 a 9). Padrão: 3.
  */
-export function generateQuestion(operation?: Operation, schoolYear: number = 3): MathQuestion {
+export function generateQuestion(
+  operation?: Operation,
+  schoolYear: number = 3,
+): MathQuestion {
   const grade = Math.max(1, Math.min(9, Math.round(schoolYear)));
   const cfg = GRADE_CONFIGS[grade] ?? GRADE_CONFIGS[3];
 
@@ -396,23 +901,41 @@ export function generateQuestion(operation?: Operation, schoolYear: number = 3):
       ? operation
       : pick<Operation>(cfg.operations);
 
-  const { text, answer, wrongOffset: customOffset } = generators[op](cfg);
-  const effectiveOffset = customOffset ?? cfg.wrongOffset;
+  const result = generators[op](cfg);
 
-  const wrongAnswer = generateWrongAnswer(answer, effectiveOffset);
+  // Resposta errada: usa a pré-calculada ou gera via offset
+  const wrongAnswer =
+    result.wrongAnswer !== undefined
+      ? result.wrongAnswer
+      : generateWrongAnswer(
+          result.answer,
+          result.wrongOffset ?? cfg.wrongOffset,
+          result.allowNegativeWrong,
+        );
+
   const correctSide: "left" | "right" = pick(["left", "right"]);
 
-  const leftValue = correctSide === "left" ? answer : wrongAnswer;
-  const rightValue = correctSide === "right" ? answer : wrongAnswer;
+  const leftValue = correctSide === "left" ? result.answer : wrongAnswer;
+  const rightValue = correctSide === "right" ? result.answer : wrongAnswer;
 
-  return {
-    text,
-    correctAnswer: answer,
+  const question: MathQuestion = {
+    text: result.text,
+    correctAnswer: result.answer,
     wrongAnswer,
     correctSide,
     leftValue,
     rightValue,
   };
+
+  // Adiciona display strings quando o gerador as fornece
+  if (result.displayCorrect !== undefined && result.displayWrong !== undefined) {
+    question.leftDisplay =
+      correctSide === "left" ? result.displayCorrect : result.displayWrong;
+    question.rightDisplay =
+      correctSide === "right" ? result.displayCorrect : result.displayWrong;
+  }
+
+  return question;
 }
 
 /**

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -47,6 +47,7 @@ let pendingText: string | null = null;
 const OPERATOR_WORDS: Record<string, string> = {
   "+": "mais",
   "-": "menos",
+  "−": "menos",
   "×": "vezes",
   "÷": "dividido por",
 };
@@ -57,6 +58,77 @@ const FRACTION_NARRATIONS: Record<string, string> = {
   "¼": "um quarto",
   "¾": "três quartos",
 };
+
+/* ── Unicode helpers para narração (#47) ── */
+
+const SUPERSCRIPTS = "⁰¹²³⁴⁵⁶⁷⁸⁹";
+const SUBSCRIPTS = "₀₁₂₃₄₅₆₇₈₉";
+
+/** Converte dígitos Unicode sobrescritos para string numérica: "²³" → "23" */
+function fromSuperscript(s: string): string {
+  return s
+    .split("")
+    .map((c) => {
+      const idx = SUPERSCRIPTS.indexOf(c);
+      return idx >= 0 ? String(idx) : c;
+    })
+    .join("");
+}
+
+/** Converte dígitos Unicode subscritos para string numérica: "₅" → "5" */
+function fromSubscript(s: string): string {
+  return s
+    .split("")
+    .map((c) => {
+      const idx = SUBSCRIPTS.indexOf(c);
+      return idx >= 0 ? String(idx) : c;
+    })
+    .join("");
+}
+
+/** Mapa de denominador para nomes em português (singular, plural). */
+const DENOMINATOR_WORDS: Record<number, [string, string]> = {
+  2: ["meio", "meios"],
+  3: ["terço", "terços"],
+  4: ["quarto", "quartos"],
+  5: ["quinto", "quintos"],
+  6: ["sexto", "sextos"],
+  8: ["oitavo", "oitavos"],
+  10: ["décimo", "décimos"],
+};
+
+/**
+ * Narra um valor de resposta, convertendo formatos especiais em texto falado.
+ *
+ * - Decimal "3,8" → "3 vírgula 8"
+ * - Fração Unicode "³⁄₅" → "3 quintos"
+ * - Negativo "−8" → "menos 8"
+ * - Número simples → string direta
+ */
+function narrateValue(value: number | string): string {
+  const s = String(value);
+
+  // Decimal brasileiro: "3,8" → "3 vírgula 8"
+  const decMatch = s.match(/^(\d+),(\d+)$/);
+  if (decMatch) return `${decMatch[1]} vírgula ${decMatch[2]}`;
+
+  // Fração Unicode: "³⁄₅" → "3 quintos"
+  const fracMatch = s.match(/^([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)$/);
+  if (fracMatch) {
+    const num = Number(fromSuperscript(fracMatch[1]));
+    const den = Number(fromSubscript(fracMatch[2]));
+    const words = DENOMINATOR_WORDS[den];
+    if (words) {
+      return `${num} ${num === 1 ? words[0] : words[1]}`;
+    }
+    return `${num} sobre ${den}`;
+  }
+
+  // Negativo com Unicode minus: "−8" → "menos 8"
+  if (s.startsWith("−")) return `menos ${s.slice(1)}`;
+
+  return s;
+}
 
 /* ── Gestão de vozes ── */
 
@@ -247,25 +319,124 @@ export function speak(text: string): void {
 /**
  * Constrói a frase de narração para uma questão de matemática.
  *
- * Suporta três formatos (#46):
+ * Suporta todos os formatos implementados (#46 + #47):
  *
  * 1. Operação simples: "12 + 15 = ?"
  *    → "Quanto é 12 mais 15? À esquerda, 27. À direita, 30."
  *
- * 2. Fração: "½ de 20 = ?"
+ * 2. Fração (5º): "½ de 20 = ?"
  *    → "Quanto é metade de 20? À esquerda, 10. À direita, 12."
  *
- * 3. Expressão: "3 × 4 + 2 = ?"
+ * 3. Expressão (5º): "3 × 4 + 2 = ?"
  *    → "Quanto é 3 vezes 4 mais 2? À esquerda, 14. À direita, 12."
+ *
+ * 4. Potenciação (6º): "2³ = ?"
+ *    → "Quanto é 2 elevado a 3? À esquerda, 8. À direita, 6."
+ *
+ * 5. Decimal (6º): "1,5 + 2,3 = ?"
+ *    → "Quanto é 1 vírgula 5 mais 2 vírgula 3? À esquerda, ..."
+ *
+ * 6. Fração mesmo denom. (6º): "²⁄₅ + ¹⁄₅ = ?"
+ *    → "Quanto é 2 quintos mais 1 quinto? À esquerda, ..."
+ *
+ * 7. Múltiplos/divisores (6º): "Múltiplo de 6 = ?"
+ *    → "Qual é o múltiplo de 6? À esquerda, 18. À direita, 16."
+ *
+ * 8. Negativos (7º): "−3 + 5 = ?"
+ *    → "Quanto é menos 3 mais 5? À esquerda, 2. À direita, 4."
+ *
+ * 9. Proporção (7º): "Se 2 → 6, 4 → ?"
+ *    → "Se 2 dá 6, quanto dá 4? À esquerda, 12. À direita, 10."
+ *
+ * 10. Parênteses (7º): "(3 + 2) × 4 = ?"
+ *     → "Quanto é, abre parênteses, 3 mais 2, fecha parênteses, vezes 4?"
+ *
+ * 11. Porcentagem (7º): "10% de 200 = ?"
+ *     → "Quanto é 10 por cento de 200? À esquerda, 20. À direita, 25."
  */
 export function buildNarration(
   questionText: string,
   leftValue: number | string,
   rightValue: number | string,
 ): string {
-  const suffix = `À esquerda, ${leftValue}. À direita, ${rightValue}.`;
+  const suffix = `À esquerda, ${narrateValue(leftValue)}. À direita, ${narrateValue(rightValue)}.`;
 
-  // 1. Fração: "½ de 20 = ?"
+  // 1. Porcentagem: "10% de 200 = ?"
+  const pctMatch = questionText.match(/^(\d+)% de (\d+)/);
+  if (pctMatch) {
+    return `Quanto é ${pctMatch[1]} por cento de ${pctMatch[2]}? ${suffix}`;
+  }
+
+  // 2. Potenciação: "2³ = ?" (dígitos + sobrescritos)
+  const expMatch = questionText.match(
+    /^(\d+)([⁰¹²³⁴⁵⁶⁷⁸⁹]+)\s*=\s*\?/,
+  );
+  if (expMatch) {
+    const base = expMatch[1];
+    const exp = fromSuperscript(expMatch[2]);
+    return `Quanto é ${base} elevado a ${exp}? ${suffix}`;
+  }
+
+  // 3. Decimal: "1,5 + 2,3 = ?"
+  const decMatch = questionText.match(
+    /^(\d+,\d+)\s*([+\-])\s*(\d+,\d+)/,
+  );
+  if (decMatch) {
+    const a = decMatch[1].replace(",", " vírgula ");
+    const op = OPERATOR_WORDS[decMatch[2]] ?? decMatch[2];
+    const b = decMatch[3].replace(",", " vírgula ");
+    return `Quanto é ${a} ${op} ${b}? ${suffix}`;
+  }
+
+  // 4. Fração mesmo denominador: "²⁄₅ + ¹⁄₅ = ?"
+  const sameFracMatch = questionText.match(
+    /^([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)\s*([+−])\s*([⁰¹²³⁴⁵⁶⁷⁸⁹]+)⁄([₀₁₂₃₄₅₆₇₈₉]+)/,
+  );
+  if (sameFracMatch) {
+    const n1 = Number(fromSuperscript(sameFracMatch[1]));
+    const d1 = Number(fromSubscript(sameFracMatch[2]));
+    const op = sameFracMatch[3] === "+" ? "mais" : "menos";
+    const n2 = Number(fromSuperscript(sameFracMatch[4]));
+    const d2 = Number(fromSubscript(sameFracMatch[5]));
+    const w1 = DENOMINATOR_WORDS[d1];
+    const w2 = DENOMINATOR_WORDS[d2];
+    const dWord1 = w1 ? (n1 === 1 ? w1[0] : w1[1]) : `sobre ${d1}`;
+    const dWord2 = w2 ? (n2 === 1 ? w2[0] : w2[1]) : `sobre ${d2}`;
+    return `Quanto é ${n1} ${dWord1} ${op} ${n2} ${dWord2}? ${suffix}`;
+  }
+
+  // 5. Múltiplos/divisores: "Múltiplo de 6 = ?" ou "Divisor de 24 = ?"
+  const mdMatch = questionText.match(/^(Múltiplo|Divisor) de (\d+)/);
+  if (mdMatch) {
+    return `Qual é o ${mdMatch[1].toLowerCase()} de ${mdMatch[2]}? ${suffix}`;
+  }
+
+  // 6. Proporção: "Se 2 → 6, 4 → ?"
+  const propMatch = questionText.match(/^Se (\d+) → (\d+), (\d+) → \?/);
+  if (propMatch) {
+    return `Se ${propMatch[1]} dá ${propMatch[2]}, quanto dá ${propMatch[3]}? ${suffix}`;
+  }
+
+  // 7. Expressão com parênteses: "(3 + 2) × 4 = ?"
+  const parenMatch = questionText.match(
+    /^\((\d+)\s*([+\-−])\s*(\d+)\)\s*([×÷])\s*(\d+)/,
+  );
+  if (parenMatch) {
+    const [, a, op1, b, op2, c] = parenMatch;
+    const word1 = OPERATOR_WORDS[op1] ?? op1;
+    const word2 = OPERATOR_WORDS[op2] ?? op2;
+    return `Quanto é, abre parênteses, ${a} ${word1} ${b}, fecha parênteses, ${word2} ${c}? ${suffix}`;
+  }
+
+  // 8. Negativos: "−3 + 5 = ?" ou "−3 − 5 = ?"
+  const negMatch = questionText.match(/^−(\d+)\s*([+−])\s*(\d+)/);
+  if (negMatch) {
+    const [, a, op, b] = negMatch;
+    const opWord = op === "+" ? "mais" : "menos";
+    return `Quanto é menos ${a} ${opWord} ${b}? ${suffix}`;
+  }
+
+  // 9. Fração (5º ano): "½ de 20 = ?"
   const fracMatch = questionText.match(/^([½¼¾])\s+de\s+(\d+)/);
   if (fracMatch) {
     const [, symbol, whole] = fracMatch;
@@ -273,7 +444,7 @@ export function buildNarration(
     return `Quanto é ${word} de ${whole}? ${suffix}`;
   }
 
-  // 2. Expressão: "3 × 4 + 2 = ?"
+  // 10. Expressão (5º ano): "3 × 4 + 2 = ?"
   const exprMatch = questionText.match(
     /^(\d+)\s*([+\-×÷])\s*(\d+)\s*([+\-×÷])\s*(\d+)/,
   );
@@ -284,7 +455,7 @@ export function buildNarration(
     return `Quanto é ${a} ${word1} ${b} ${word2} ${c}? ${suffix}`;
   }
 
-  // 3. Operação simples: "12 + 15 = ?"
+  // 11. Operação simples: "12 + 15 = ?"
   const match = questionText.match(/^(\d+)\s*([+\-×÷])\s*(\d+)/);
   if (!match) return "";
 


### PR DESCRIPTION
## Issue #47 — Conteúdos do 6º e 7º ano

### 6º ano
- **Potenciação simples** (2³ = ?) — exibição com sobrescrito Unicode
- **Operações com decimais** (1,5 + 2,3 = ?) — formato brasileiro (vírgula)
- **Frações com mesmo denominador** (²⁄₅ + ¹⁄₅ = ?) — Unicode fractions
- **Múltiplos e divisores** — distratores inteligentes (não-múltiplo/não-divisor)

### 7º ano
- **Números negativos** (−3 + 5 = ?) — Unicode minus, respostas podem ser negativas
- **Proporções simples** (Se 2 → 6, 4 → ?)
- **Expressões com parênteses** ((3 + 2) × 4 = ?)
- **Porcentagens simples** (10% de 200 = ?)

### Narração atualizada
- Potência: "2 elevado a 3"
- Decimal: "1 vírgula 5 mais 2 vírgula 3"
- Frações: "2 quintos mais 1 quinto" (terços/quartos/quintos/sextos/oitavos)
- Múltiplos: "qual é o múltiplo de 6"
- Negativos: "menos 3 mais 5"
- Proporção: "se 2 dá 6, quanto dá 4"
- Parênteses: "abre parênteses, 3 mais 2, fecha parênteses, vezes 4"
- Porcentagem: "10 por cento de 200"

### Display
- / opcionais em MathQuestion para formatos especiais
- GameScreen passa displays para AnswerOption e buildNarration
- Formatos: decimais (3,8), frações Unicode (³⁄₅), negativos (−7)

### Testes
- **181 testes** (153 generateQuestion + 28 speech) — todos passando
- Build OK

Closes #47